### PR TITLE
Fix/qa eval

### DIFF
--- a/agentflow_cli/cli/commands/eval.py
+++ b/agentflow_cli/cli/commands/eval.py
@@ -354,7 +354,11 @@ class EvalCommand(BaseCommand):
             criteria = self._default_config().criteria
 
         print(f"Criteria  source: {source}", flush=True)  # noqa: T201
-        for name, cfg in criteria.items():
+        for name in criteria.model_fields:
+            cfg = getattr(criteria, name)
+            if cfg is None:
+                continue
+
             parts = [f"threshold={cfg.threshold}"]
             parts.append(cfg.match_type.value)
             if cfg.judge_model:

--- a/agentflow_cli/cli/commands/eval.py
+++ b/agentflow_cli/cli/commands/eval.py
@@ -428,10 +428,13 @@ class EvalCommand(BaseCommand):
 
         async def _run_simulation(ps: _PendingSimulation) -> tuple[str, str, str, EvalCaseResult]:
             from agentflow.qa.evaluation.eval_result import CriterionResult
+            from agentflow.qa.evaluation.token_usage import TokenUsage
 
             try:
                 sim_result = await ps.simulator.run(ps.graph, ps.scenario)
-                criterion_results = [
+                # Use the full CriterionResult objects (with per-criterion token_usage)
+                # if available; fall back to rebuilding from scores dict.
+                criterion_results = sim_result.criterion_results or [
                     CriterionResult.success(
                         criterion=name,
                         score=score,
@@ -455,11 +458,17 @@ class EvalCommand(BaseCommand):
                 conversation_text = "\n".join(
                     f"{m['role'].upper()}: {m['content']}" for m in sim_result.conversation
                 )
+                criteria_token_usage = sum(
+                    (cr.token_usage for cr in criterion_results), TokenUsage()
+                )
+                total_token_usage = sim_result.simulator_token_usage + criteria_token_usage
                 result = EvalCaseResult.success(
                     eval_id=ps.scenario.scenario_id,
                     name=ps.scenario.description or ps.scenario.scenario_id,
                     criterion_results=criterion_results,
                     actual_response=conversation_text,
+                    token_usage=total_token_usage,
+                    agent_token_usage=sim_result.simulator_token_usage,
                     metadata={
                         "turns": sim_result.turns,
                         "goals_achieved": sim_result.goals_achieved,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "10xscale-agentflow-cli"
-version = "0.3.2.5"
+version = "0.3.2.6"
 description = "CLI and API for 10xscale AgentFlow"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
This pull request makes several improvements to the evaluation command in the CLI, focusing on more robust handling of evaluation criteria, enhanced token usage tracking, and minor version bump. The changes improve reliability when printing criteria, ensure accurate aggregation of token usage, and maintain compatibility with possible changes in simulation result formats.

Key improvements include:

**Evaluation criteria handling:**
* Improved iteration over evaluation criteria to handle cases where some criteria may be unset, preventing errors and skipping `None` values when printing criteria blocks.

**Token usage tracking:**
* Enhanced token usage aggregation by summing both simulator and per-criterion token usage, and including both in the `EvalCaseResult`. This ensures more accurate reporting and accounting of token usage in evaluation results.
* Updated simulation result processing to use full `CriterionResult` objects with per-criterion token usage when available, but gracefully fall back to reconstructing results from scores if not, improving robustness to changes in result formats.

**Versioning:**
* Bumped the CLI package version to `0.3.2.6` to reflect these changes.