### PR TITLE
fix(eval): isolate per-case trajectory capture under parallel runs

### DIFF
--- a/agentflow_cli/cli/commands/eval.py
+++ b/agentflow_cli/cli/commands/eval.py
@@ -17,15 +17,12 @@ from typing import TYPE_CHECKING, Any
 from agentflow.qa.evaluation import CriteriaConfig, CriterionConfig, EvalConfig
 from agentflow.qa.evaluation.collectors.trajectory_collector import (
     TrajectoryCollector,
-    make_trajectory_callback,
 )
 from agentflow.qa.evaluation.config.eval_config import ReporterConfig
 from agentflow.qa.evaluation.eval_result import EvalCaseResult
 from agentflow.qa.evaluation.eval_result import EvalReport as ER
 from agentflow.qa.evaluation.evaluator import AgentEvaluator
 from agentflow.qa.evaluation.reporters.manager import ReporterManager
-from agentflow.utils.callbacks import CallbackManager
-from injectq.testing import override_dependency
 
 from agentflow_cli.cli.commands import BaseCommand
 from agentflow_cli.cli.core.config import ConfigManager
@@ -52,29 +49,6 @@ class _PendingSimulation:
     file_name: str
     eval_set_id: str
     eval_set_name: str
-
-
-def _reset_inject_proxy(service_type: type) -> None:
-    """Reset the lazy Inject[T] proxy cached on Node.execute's default parameters.
-
-    Inject[T] proxies cache their resolved value in _injected_value on first use.
-    container.override() clears the singleton scope, but the proxy's own cache is
-    independent — it must be cleared so the proxy re-resolves from the container
-    on next invocation instead of returning the stale value.
-    """
-    try:
-        from agentflow.core.graph.node import Node as _GraphNode
-
-        defaults = getattr(_GraphNode.execute, "__defaults__", None) or ()
-        for d in defaults:
-            if (
-                hasattr(d, "_injected_value")
-                and hasattr(d, "service_type")
-                and d.service_type is service_type
-            ):
-                d._injected_value = None
-    except Exception:  # nosec B110  # noqa: S110
-        pass
 
 
 DEFAULT_CONCURRENCY = 4
@@ -408,26 +382,23 @@ class EvalCommand(BaseCommand):
         completed = 0
 
         async def _run_case(pc: _PendingCase) -> tuple[str, str, str, EvalCaseResult]:
+            # A fresh collector per case isolates capture. The evaluator wires it
+            # into the graph's live CallbackManager itself (re-pointing capture to
+            # this collector for the duration of the case), so no container
+            # override or Inject-proxy reset is needed here.
             local_collector = TrajectoryCollector(
                 capture_all_events=pc.evaluator.collector.capture_all_events,
             )
-            _, local_mgr = make_trajectory_callback(local_collector)
-            container = pc.evaluator.graph._state_graph._container
-            # The Inject[CallbackManager] proxy on Node.execute caches its resolved
-            # value independently of the container — reset it so it re-resolves
-            # inside the override context instead of returning the stale instance.
-            _reset_inject_proxy(CallbackManager)
-            with override_dependency(CallbackManager, local_mgr, container=container):
-                try:
-                    result = await pc.evaluator._evaluate_case(
-                        pc.case, collector_override=local_collector
-                    )
-                except Exception as exc:
-                    result = EvalCaseResult.failure(
-                        eval_id=pc.case.eval_id,
-                        error=str(exc),
-                        name=pc.case.name,
-                    )
+            try:
+                result = await pc.evaluator._evaluate_case(
+                    pc.case, collector_override=local_collector
+                )
+            except Exception as exc:
+                result = EvalCaseResult.failure(
+                    eval_id=pc.case.eval_id,
+                    error=str(exc),
+                    name=pc.case.name,
+                )
             return (pc.file_name, pc.eval_set_id, pc.eval_set_name, result)
 
         async def _run_simulation(ps: _PendingSimulation) -> tuple[str, str, str, EvalCaseResult]:


### PR DESCRIPTION
## Summary

Under `parallel: true` (from `agentflow.json`), concurrent eval cases shared a single graph, and the per-case container override — `override_dependency(CallbackManager, ...)` — re-pointed the **global** callback mid-flight. The result was cross-case bleed: turns counted as `0/2/4`, duplicate tool calls, and capture attributed to the wrong case.

## Fix

`_run_case` now just builds a fresh per-case `TrajectoryCollector` and passes it via `collector_override`. The evaluator's new **task-local dispatcher** (see the companion agentflow PR) handles wiring into the graph's live `CallbackManager`, so the CLI no longer needs to touch the DI container at all.

Removed as now-obsolete:
- the `override_dependency(CallbackManager, ...)` context
- the `_reset_inject_proxy` helper
- the per-case `local_mgr`
- the unused `make_trajectory_callback`, `CallbackManager`, and `override_dependency` imports

## Depends on

Pairs with the agentflow change that installs the task-local collector dispatcher: 10xHub/Agentflow#126.

## Testing

- `tests/cli/test_eval_discovery.py`, `tests/cli/test_eval_flat_pool.py` → **26 passed**
- All pre-commit hooks pass on the changed file
