### PR TITLE
Improve/cli UI ux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `init`, `build`, `test`, `eval`, `doctor`, and `skills`, previewable with the
   side-effect-free `agentflow demo`.
 - Row-by-row reveal for completion panels.
+- **Shared guided-prompt layer** (`cli/core/prompts.py`). Every interactive
+  question now runs through one themed service, so prompts share a palette, a
+  cancellation contract (Ctrl+C returns to a clean exit rather than a
+  traceback), and one non-interactive policy.
+- `agentflow skills` picks agents with an arrow-key list where **space toggles**
+  and enter confirms, instead of typing a menu number. Each row shows its
+  install path, already-installed agents are labelled and pre-checked, and
+  choosing one that exists offers to overwrite rather than failing.
+- `agentflow skills` reports installs through a timeline and a completion
+  screen, matching every other command.
+- `agentflow init` prompts now explain each option inline — what Quick Start
+  versus Production scaffolds, what each auth mode requires, what each rate
+  limit backend costs.
 - Staged startup feedback, a pre-flight port check, and connected-playground
   completion output for `agentflow play` and `agentflow dev`.
 - Adaptive `--animation` / `--no-animation` controls with CI, pipe, JSON, and
@@ -99,6 +112,15 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - A console that reports itself as a terminal but refuses the alternate buffer
   (legacy Windows console) now aborts the frame before anything is written,
   rather than leaving a scrolling region on the user's real scrollback.
+- **A terminal that cannot host a prompt no longer crashes the command.**
+  `stdin.isatty()` is true under MSYS/Cygwin shells on Windows, but
+  prompt-toolkit cannot attach to a console there and raises — which surfaced as
+  `AF-INTERNAL-001: Unexpected error: Found xterm-256color, while expecting a
+  Windows console`. Prompt availability is now probed, so such a terminal counts
+  as non-interactive and gets the usual "pass --agent or --all" guidance.
+- Pinned chrome is repainted after each prompt. Prompt-toolkit erases from the
+  cursor to the end of the *screen*, which reaches past the scrolling region and
+  took the footer with it.
 - One Rich `Console` is now reused per stream. Rebuilding it per call meant a live
   display could not tell that ordinary prints belonged to it, so background output
   collided with spinners and progress bars instead of scrolling above them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,21 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Persistent full-screen application surface.** On an interactive terminal a
+  command now runs on its own screen with branded chrome pinned in place: a
+  header (gradient rule, identity, version, subtitle) at the top, a footer
+  status bar at the bottom, and the command's output scrolling between them.
+  Pinning uses a DEC scrolling region, so it survives output from child
+  processes — pytest, Uvicorn, Questionary prompts — without routing any of it
+  through a renderer. The screen is held until you press Enter, and released
+  through a `finally` guard so a crash can never leave your shell on an
+  alternate buffer or inside a scrolling region. Opt out with `--no-fullscreen`
+  or `AGENTFLOW_NO_FULLSCREEN=1`.
 - Full-canvas animated command intro: an eased block-letter `AGENTFLOW` reveal
   with a moving light front, a flowing gradient field, a typed tagline, and a
-  per-command pipeline that fills in as the intro plays. It runs on a temporary
-  alternate screen and hands the terminal back, so the animation gets the whole
-  canvas while the command's real output stays in scrollback.
-- Persistent branded session header (gradient rules, command, version, and
-  subtitle) printed into the normal buffer after the intro.
+  per-command pipeline that fills in as the intro plays. Inside the full-screen
+  surface it collapses into the pinned header; with `--no-fullscreen` it plays
+  on a temporary screen and leaves a durable header in your scrollback.
 - Live step timelines (`OutputFormatter.timeline`): a command declares its stages
   up front, so pending work is visible from the first frame while the running
   stage animates with a spinner, elapsed timer, and a live detail line. Wired
@@ -44,8 +52,6 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `init`, `build`, `test`, `eval`, `doctor`, and `skills`, previewable with the
   side-effect-free `agentflow demo`.
 - Row-by-row reveal for completion panels.
-- Opt-in `--fullscreen` (or `AGENTFLOW_FULLSCREEN=1`) that runs a command on a
-  painted alternate screen and holds it until you press Enter.
 - Staged startup feedback, a pre-flight port check, and connected-playground
   completion output for `agentflow play` and `agentflow dev`.
 - Adaptive `--animation` / `--no-animation` controls with CI, pipe, JSON, and
@@ -81,12 +87,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   working directory.
 - Init, build, and eval status output now flows through the shared renderer instead of
   writing raw ANSI control sequences.
-- The alternate screen is no longer held for a command's whole lifetime. A terminal
-  discards an alternate screen when it is released, so that approach erased each
-  command's output on exit and made short commands look like a flash of nothing.
-  Motion now owns the screen only while it is playing; results are written to the
-  normal buffer. `--fullscreen` restores the held-screen behavior for anyone who
-  wants it, and pauses before releasing so nothing is lost.
+- **The full-screen session no longer erases the command's output.** It used to
+  hold the alternate screen through a Rich live display, which re-homes the
+  cursor before every write — so each line overwrote the last — and then released
+  the screen on exit, which a terminal handles by discarding everything drawn on
+  it. Short commands showed a flash of nothing. The frame now switches the buffer
+  directly and pauses on a closing hint before letting go.
+- The screen is claimed lazily, by the first command that renders a header.
+  Script-shaped invocations (`--version`, `config get`, `--format json`) never
+  take over the terminal or pause on exit.
+- A console that reports itself as a terminal but refuses the alternate buffer
+  (legacy Windows console) now aborts the frame before anything is written,
+  rather than leaving a scrolling region on the user's real scrollback.
 - One Rich `Console` is now reused per stream. Rebuilding it per call meant a live
   display could not tell that ordinary prints belonged to it, so background output
   collided with spinners and progress bars instead of scrolling above them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,18 +24,33 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Terminal-native frame animation for interactive commands, plus reusable
-  animated activities, timed state transitions, and completion panels.
-- Command-specific network, scaffold, delivery-pipeline, and evaluation-scan
-  animation themes, with a side-effect-free `agentflow demo` preview command.
-- Alternate-screen `AGENTFLOW` typing reveal and full-canvas background
-  transition for `play` and `dev`, previewable with `demo --style typing`.
-- Invocation-scoped alternate-screen ownership so every animated command keeps
-  its themed background until completion or interruption.
-- Staged startup feedback and connected-playground completion output for
-  `agentflow play` and `agentflow dev`.
+- Full-canvas animated command intro: an eased block-letter `AGENTFLOW` reveal
+  with a moving light front, a flowing gradient field, a typed tagline, and a
+  per-command pipeline that fills in as the intro plays. It runs on a temporary
+  alternate screen and hands the terminal back, so the animation gets the whole
+  canvas while the command's real output stays in scrollback.
+- Persistent branded session header (gradient rules, command, version, and
+  subtitle) printed into the normal buffer after the intro.
+- Live step timelines (`OutputFormatter.timeline`): a command declares its stages
+  up front, so pending work is visible from the first frame while the running
+  stage animates with a spinner, elapsed timer, and a live detail line. Wired
+  into `play`/`dev`/`api`, `init`, `build`, `test`, and `doctor`.
+- Determinate progress with a running pass/fail tally
+  (`OutputFormatter.progress_run`), used by `agentflow eval` so per-case results
+  scroll above a bar that reports completion, counts, and elapsed time.
+- Shared brand palette and glyph sets (`cli/core/theme.py`) with continuous
+  gradient sampling and a complete ASCII fallback set.
+- Command-specific intro signatures and taglines for `play`, `dev`, `api`,
+  `init`, `build`, `test`, `eval`, `doctor`, and `skills`, previewable with the
+  side-effect-free `agentflow demo`.
+- Row-by-row reveal for completion panels.
+- Opt-in `--fullscreen` (or `AGENTFLOW_FULLSCREEN=1`) that runs a command on a
+  painted alternate screen and holds it until you press Enter.
+- Staged startup feedback, a pre-flight port check, and connected-playground
+  completion output for `agentflow play` and `agentflow dev`.
 - Adaptive `--animation` / `--no-animation` controls with CI, pipe, JSON, and
-  accessibility-safe fallbacks.
+  accessibility-safe fallbacks. Every animated surface has a plain
+  line-per-transition renderer and a versioned JSON/JSONL event renderer.
 - Adaptive Rich terminal rendering with TTY/CI detection, plain/JSONL modes,
   `NO_COLOR` support, ASCII fallback, quiet mode, and shared status rendering.
 - Root `--format`, `--json`, `--color`, `--no-color`, `--progress`, `--cwd`,
@@ -66,6 +81,17 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   working directory.
 - Init, build, and eval status output now flows through the shared renderer instead of
   writing raw ANSI control sequences.
+- The alternate screen is no longer held for a command's whole lifetime. A terminal
+  discards an alternate screen when it is released, so that approach erased each
+  command's output on exit and made short commands look like a flash of nothing.
+  Motion now owns the screen only while it is playing; results are written to the
+  normal buffer. `--fullscreen` restores the held-screen behavior for anyone who
+  wants it, and pauses before releasing so nothing is lost.
+- One Rich `Console` is now reused per stream. Rebuilding it per call meant a live
+  display could not tell that ordinary prints belonged to it, so background output
+  collided with spinners and progress bars instead of scrolling above them.
+- `agentflow init` no longer prints one line per scaffolded file; files stream through
+  the active timeline row instead.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Adaptive Rich terminal rendering with TTY/CI detection, plain/JSONL modes,
+  `NO_COLOR` support, ASCII fallback, quiet mode, and shared status rendering.
+- Root `--format`, `--json`, `--color`, `--no-color`, `--progress`, `--cwd`,
+  `--yes`, `--non-interactive`, `--debug`, and `-V/--version` options.
+- `agentflow dev` as the goal-oriented local development command; `api` and `play`
+  remain available for compatibility.
+- `agentflow doctor` package, evaluation API, project configuration, and port checks.
+- Cross-platform `agentflow config list|get|set|unset|path|validate` user preferences.
+- Reproducible `agentflow init --non-interactive` recipes and `--dry-run` previews.
+- Stable CLI error codes and dependency recovery suggestions.
 - `py.typed` marker, so type information now reaches consumers (PEP 561).
 - `--integration` pytest flag gating tests marked `integration` that require real
   Redis/Postgres, so a default `pytest` run needs no external services.
@@ -33,6 +43,17 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Community health files: `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`,
   `RELEASE_NOTES.md`, issue forms, and a pull request template.
 - `Changelog` entry in project URLs.
+
+### Changed
+
+- Command implementations are loaded lazily, so a broken optional feature no longer
+  prevents root help, version, completion, or unrelated commands from starting.
+- CLI logging now uses one invocation-wide handler, so quiet and verbose levels apply
+  consistently without duplicate records.
+- Project configuration discovery now walks parent directories from the current
+  working directory.
+- Init, build, and eval status output now flows through the shared renderer instead of
+  writing raw ANSI control sequences.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Terminal-native frame animation for interactive commands, plus reusable
   animated activities, timed state transitions, and completion panels.
+- Command-specific network, scaffold, delivery-pipeline, and evaluation-scan
+  animation themes, with a side-effect-free `agentflow demo` preview command.
+- Alternate-screen `AGENTFLOW` typing reveal and full-canvas background
+  transition for `play` and `dev`, previewable with `demo --style typing`.
+- Invocation-scoped alternate-screen ownership so every animated command keeps
+  its themed background until completion or interruption.
 - Staged startup feedback and connected-playground completion output for
   `agentflow play` and `agentflow dev`.
 - Adaptive `--animation` / `--no-animation` controls with CI, pipe, JSON, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Terminal-native frame animation for interactive commands, plus reusable
+  animated activities, timed state transitions, and completion panels.
+- Staged startup feedback and connected-playground completion output for
+  `agentflow play` and `agentflow dev`.
+- Adaptive `--animation` / `--no-animation` controls with CI, pipe, JSON, and
+  accessibility-safe fallbacks.
 - Adaptive Rich terminal rendering with TTY/CI detection, plain/JSONL modes,
   `NO_COLOR` support, ASCII fallback, quiet mode, and shared status rendering.
 - Root `--format`, `--json`, `--color`, `--no-color`, `--progress`, `--cwd`,

--- a/README.md
+++ b/README.md
@@ -122,11 +122,20 @@ agentflow dev --no-open --no-reload        # API only, without auto-reload
 ### Adaptive and structured output
 
 ```bash
+agentflow play                         # animated in an interactive terminal
+agentflow --no-animation play          # accessible/static workflow
+agentflow --animation doctor           # force the animation showcase
 agentflow --format plain --no-color doctor
 agentflow --format jsonl eval --parallel
 agentflow --quiet build
 agentflow --cwd ../my-agent dev
 ```
+
+Interactive commands use a short terminal-native Agentflow reveal, animated
+activity states, and polished completion panels. Motion is automatically
+disabled for redirected output, CI, `TERM=dumb`, JSON/JSONL, and
+`AGENTFLOW_NO_SPINNER=1`. Use `--no-animation` for a stable screen-reader
+friendly experience or `--animation` to force motion in a compatible terminal.
 
 ### `agentflow build`
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ agentflow dev --no-open --no-reload        # API only, without auto-reload
 
 ```bash
 agentflow play                         # animated in an interactive terminal
+agentflow demo                         # preview every animation theme safely
+agentflow demo --style typing          # full-screen AGENTFLOW typing reveal
+agentflow demo --style build           # preview one command theme
 agentflow --no-animation play          # accessible/static workflow
 agentflow --animation doctor           # force the animation showcase
 agentflow --format plain --no-color doctor
@@ -136,6 +139,13 @@ activity states, and polished completion panels. Motion is automatically
 disabled for redirected output, CI, `TERM=dumb`, JSON/JSONL, and
 `AGENTFLOW_NO_SPINNER=1`. Use `--no-animation` for a stable screen-reader
 friendly experience or `--animation` to force motion in a compatible terminal.
+
+Every animated command owns one themed alternate-screen workspace for its full
+lifetime. `play` and `dev` type the Agentflow identity and remain on that
+background while the server runs; `api` animates a live graph network, `init`
+assembles a project scaffold, `build` advances a delivery pipeline, and
+`test`/`eval` scan through completion states. The original terminal buffer is
+restored only after the command exits or is interrupted.
 
 ### `agentflow build`
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ agentflow build --docker-compose
 ## 🖥️ CLI Commands
 
 Run `agentflow --help` or `agentflow COMMAND --help` for the generated command reference.
-The modernization architecture and delivery roadmap are documented in
-[`CLI_UX_IMPLEMENTATION_PLAN.md`](./CLI_UX_IMPLEMENTATION_PLAN.md).
 
 ### `agentflow init`
 
@@ -122,30 +120,40 @@ agentflow dev --no-open --no-reload        # API only, without auto-reload
 ### Adaptive and structured output
 
 ```bash
-agentflow play                         # animated in an interactive terminal
-agentflow demo                         # preview every animation theme safely
-agentflow demo --style typing          # full-screen AGENTFLOW typing reveal
+agentflow play                         # full-screen surface in an interactive terminal
+agentflow demo                         # preview the animation and progress states safely
 agentflow demo --style build           # preview one command theme
+agentflow --no-fullscreen play         # keep output in your normal scrollback
 agentflow --no-animation play          # accessible/static workflow
-agentflow --animation doctor           # force the animation showcase
 agentflow --format plain --no-color doctor
 agentflow --format jsonl eval --parallel
 agentflow --quiet build
 agentflow --cwd ../my-agent dev
 ```
 
-Interactive commands use a short terminal-native Agentflow reveal, animated
-activity states, and polished completion panels. Motion is automatically
-disabled for redirected output, CI, `TERM=dumb`, JSON/JSONL, and
-`AGENTFLOW_NO_SPINNER=1`. Use `--no-animation` for a stable screen-reader
-friendly experience or `--animation` to force motion in a compatible terminal.
+On an interactive terminal a command runs on its own full-screen surface: a
+pinned header (identity, version, subtitle), a pinned footer status bar, and the
+command's output scrolling between them. The intro reveals the Agentflow
+wordmark on the full canvas and collapses into that header, and each command
+shows its own pipeline — `play`/`dev` config→runtime→server→playground, `init`
+template→graph→config→project, `build` source→deps→image→ship, `eval`
+discover→load→score→report.
 
-Every animated command owns one themed alternate-screen workspace for its full
-lifetime. `play` and `dev` type the Agentflow identity and remain on that
-background while the server runs; `api` animates a live graph network, `init`
-assembles a project scaffold, `build` advances a delivery pipeline, and
-`test`/`eval` scan through completion states. The original terminal buffer is
-restored only after the command exits or is interrupted.
+The surface is held until you press Enter, so a fast command cannot erase its
+own result. Pass `--no-fullscreen` (or set `AGENTFLOW_NO_FULLSCREEN=1`) to keep
+everything in your normal scrollback instead — useful when you want to scroll
+back or copy a path afterwards.
+
+Long-running work reports through a live step timeline: stages are declared up
+front, pending ones stay dimmed, and the running one animates with an elapsed
+timer. `agentflow eval` uses a determinate progress bar with a running pass/fail
+tally.
+
+Motion is disabled automatically for redirected output, CI, `TERM=dumb`,
+JSON/JSONL, and `AGENTFLOW_NO_SPINNER=1`. Use `--no-animation` for a stable
+screen-reader friendly experience, or `--animation` to force motion in a
+compatible terminal. Every animated surface has a plain line-per-transition
+renderer and a versioned JSON/JSONL event renderer.
 
 ### `agentflow build`
 
@@ -172,10 +180,16 @@ agentflow test --coverage
 Install bundled coding-agent skills (Codex, Claude, GitHub Copilot) into your project so your AI assistant knows how to build with Agentflow.
 
 ```bash
+agentflow skills                # pick agents interactively (space toggles, enter confirms)
 agentflow skills --all          # install for every supported agent
 agentflow skills --agent claude # install for one
 agentflow skills --list         # show supported agents
+agentflow skills --force        # overwrite an existing install
 ```
+
+Run without flags to get a checklist of the supported agents. Each row shows
+where it installs, agents that are already set up are labelled and pre-checked,
+and picking one that exists offers to overwrite rather than failing.
 
 ### `agentflow version`
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ agentflow build --docker-compose
 
 ## 🖥️ CLI Commands
 
-For detailed command documentation, see the **[CLI Guide](./docs/cli-guide.md)**.
+Run `agentflow --help` or `agentflow COMMAND --help` for the generated command reference.
+The modernization architecture and delivery roadmap are documented in
+[`CLI_UX_IMPLEMENTATION_PLAN.md`](./CLI_UX_IMPLEMENTATION_PLAN.md).
 
 ### `agentflow init`
 
@@ -98,28 +100,32 @@ Initialize a new project with configuration and a sample graph.
 agentflow init                  # interactive (chooses dev vs production setup)
 agentflow init --path ./my-app  # custom directory
 agentflow init --force          # overwrite existing files
+agentflow init --path ./my-app --name MyAgent --template quick-start \
+  --non-interactive            # reproducible CI/agent workflow
+agentflow init --path ./my-app --template production --auth jwt \
+  --rate-limit redis --yes --dry-run
 ```
 
-### `agentflow api`
+### `agentflow dev`
 
-Start the development API server.
+Start the development API server and open the hosted playground when it is ready.
 
 ```bash
-agentflow api                              # defaults (127.0.0.1:8000)
-agentflow api --host 127.0.0.1 --port 9000 # custom host/port
-agentflow api --config production.json     # custom config file
-agentflow api --no-reload                  # disable auto-reload
-agentflow api --verbose                    # verbose logging
+agentflow dev                              # defaults (127.0.0.1:8000)
+agentflow dev --host 127.0.0.1 --port 9000 # custom host/port
+agentflow dev --config production.json     # custom config file
+agentflow dev --no-open --no-reload        # API only, without auto-reload
 ```
 
-### `agentflow play`
+`agentflow api` and `agentflow play` remain available as compatibility commands.
 
-Start the dev server and open the hosted playground with your local backend URL preconfigured.
+### Adaptive and structured output
 
 ```bash
-agentflow play
-agentflow play --host 127.0.0.1 --port 9000
-agentflow play --config production.json
+agentflow --format plain --no-color doctor
+agentflow --format jsonl eval --parallel
+agentflow --quiet build
+agentflow --cwd ../my-agent dev
 ```
 
 ### `agentflow build`
@@ -157,7 +163,20 @@ agentflow skills --list         # show supported agents
 Display CLI and package version information.
 
 ```bash
+agentflow --version            # script-friendly CLI version only
 agentflow version
+```
+
+### `agentflow doctor` / `agentflow config`
+
+Diagnose the local package/project environment and manage cross-platform user preferences.
+
+```bash
+agentflow doctor
+agentflow config path
+agentflow config set output.format plain
+agentflow config get output.format
+agentflow config validate
 ```
 
 ---

--- a/agentflow_cli/cli/capabilities.py
+++ b/agentflow_cli/cli/capabilities.py
@@ -1,0 +1,119 @@
+"""Terminal capability and output-mode detection for the CLI."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TextIO
+
+
+class OutputFormat(StrEnum):
+    """Supported user-facing output formats."""
+
+    HUMAN = "human"
+    PLAIN = "plain"
+    JSON = "json"
+    JSONL = "jsonl"
+
+
+class ColorMode(StrEnum):
+    """Color rendering policy."""
+
+    AUTO = "auto"
+    ALWAYS = "always"
+    NEVER = "never"
+
+
+class ProgressMode(StrEnum):
+    """Progress rendering policy."""
+
+    AUTO = "auto"
+    TTY = "tty"
+    PLAIN = "plain"
+    JSON = "json"
+    QUIET = "quiet"
+
+
+@dataclass(frozen=True)
+class TerminalCapabilities:
+    """Resolved capabilities for one CLI invocation."""
+
+    interactive: bool
+    is_ci: bool
+    color: bool
+    unicode: bool
+    animation: bool
+    output_format: OutputFormat
+    progress_mode: ProgressMode
+
+    @classmethod
+    def detect(
+        cls,
+        *,
+        stream: TextIO | None = None,
+        output_format: OutputFormat = OutputFormat.HUMAN,
+        color_mode: ColorMode = ColorMode.AUTO,
+        progress_mode: ProgressMode = ProgressMode.AUTO,
+    ) -> TerminalCapabilities:
+        """Detect terminal behavior while honoring explicit user policy."""
+        target = stream or sys.stdout
+        is_tty = bool(getattr(target, "isatty", lambda: False)())
+        is_ci = _truthy_env("CI")
+        term_is_dumb = os.environ.get("TERM", "").lower() == "dumb"
+        no_color = "NO_COLOR" in os.environ
+
+        effective_format = output_format
+        if output_format == OutputFormat.HUMAN and not is_tty:
+            effective_format = OutputFormat.PLAIN
+
+        if color_mode == ColorMode.ALWAYS:
+            color = True
+        elif color_mode == ColorMode.NEVER:
+            color = False
+        else:
+            color = is_tty and not is_ci and not term_is_dumb and not no_color
+
+        if progress_mode == ProgressMode.AUTO:
+            effective_progress = (
+                ProgressMode.TTY
+                if is_tty and not is_ci and effective_format == OutputFormat.HUMAN
+                else ProgressMode.PLAIN
+            )
+        else:
+            effective_progress = progress_mode
+
+        structured = effective_format in {OutputFormat.JSON, OutputFormat.JSONL}
+        animation = (
+            effective_progress == ProgressMode.TTY
+            and not structured
+            and not _truthy_env("AGENTFLOW_NO_SPINNER")
+        )
+        encoding = getattr(target, "encoding", None)
+        try:
+            if encoding:
+                "✓→•".encode(encoding)
+            encoding_supports_unicode = True
+        except UnicodeEncodeError:
+            encoding_supports_unicode = False
+        unicode = (
+            not term_is_dumb
+            and encoding_supports_unicode
+            and os.environ.get("AGENTFLOW_ASCII", "").lower() not in {"1", "true", "yes"}
+        )
+
+        return cls(
+            interactive=is_tty and not is_ci,
+            is_ci=is_ci,
+            color=color and not structured,
+            unicode=unicode,
+            animation=animation,
+            output_format=effective_format,
+            progress_mode=effective_progress,
+        )
+
+
+def _truthy_env(name: str) -> bool:
+    value = os.environ.get(name, "")
+    return value.lower() in {"1", "true", "yes", "on"}

--- a/agentflow_cli/cli/capabilities.py
+++ b/agentflow_cli/cli/capabilities.py
@@ -60,7 +60,7 @@ class TerminalCapabilities:
         """Detect terminal behavior while honoring explicit user policy."""
         target = stream or sys.stdout
         is_tty = bool(getattr(target, "isatty", lambda: False)())
-        is_ci = _truthy_env("CI")
+        is_ci = truthy_env("CI")
         term_is_dumb = os.environ.get("TERM", "").lower() == "dumb"
         no_color = "NO_COLOR" in os.environ
 
@@ -88,7 +88,7 @@ class TerminalCapabilities:
         animation = (
             effective_progress == ProgressMode.TTY
             and not structured
-            and not _truthy_env("AGENTFLOW_NO_SPINNER")
+            and not truthy_env("AGENTFLOW_NO_SPINNER")
         )
         encoding = getattr(target, "encoding", None)
         try:
@@ -114,6 +114,7 @@ class TerminalCapabilities:
         )
 
 
-def _truthy_env(name: str) -> bool:
+def truthy_env(name: str) -> bool:
+    """Read an environment variable as an opt-in boolean flag."""
     value = os.environ.get(name, "")
     return value.lower() in {"1", "true", "yes", "on"}

--- a/agentflow_cli/cli/commands/api.py
+++ b/agentflow_cli/cli/commands/api.py
@@ -62,51 +62,72 @@ class APICommand(BaseCommand):
                 "Starting development server via Uvicorn. Not for production use.",
             )
 
-            with self.output.activity(
-                "Discovering and validating the project",
-                done="Project configuration validated",
-                spinner="aesthetic",
-            ):
-                validated_options = validate_cli_options(host, port, config)
-                config_manager = ConfigManager()
-                actual_config_path = config_manager.find_config_file(validated_options["config"])
-                config_manager.load_config(str(actual_config_path))
-
-            with self.output.activity(
-                "Loading environment and graph runtime",
-                done="Runtime environment prepared",
-                spinner="bouncingBar",
-            ):
-                env_file_path = config_manager.resolve_env_file()
-                if env_file_path:
-                    self.logger.info("Loading environment from: %s", env_file_path)
-                    load_dotenv(env_file_path)
-                else:
-                    load_dotenv()
-
-                os.environ["GRAPH_PATH"] = str(actual_config_path)
-
-                # Add project root to sys.path for importing graph modules
-                sys.path.insert(0, str(actual_config_path.parent))
-
-                # Ensure we're using the correct module path
-                sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-
-            self.logger.info(
-                "Starting API with config: %s, host: %s, port: %d",
-                actual_config_path,
-                validated_options["host"],
-                validated_options["port"],
+            timeline = self.output.timeline(
+                "Preparing the Agentflow runtime",
+                steps=(
+                    ("config", "Validating project configuration"),
+                    ("runtime", "Loading environment and graph runtime"),
+                    ("port", f"Reserving port {port}"),
+                    ("launch", "Starting the development server"),
+                ),
             )
+            with timeline:
+                with timeline.step("config") as step:
+                    validated_options = validate_cli_options(host, port, config)
+                    config_manager = ConfigManager()
+                    actual_config_path = config_manager.find_config_file(
+                        validated_options["config"]
+                    )
+                    config_manager.load_config(str(actual_config_path))
+                    step.detail(str(actual_config_path))
 
-            if open_playground:
-                self._schedule_playground_launch(
-                    host=validated_options["host"],
-                    port=validated_options["port"],
-                    playground_base_url=playground_url,
-                )
+                with timeline.step("runtime") as step:
+                    env_file_path = config_manager.resolve_env_file()
+                    if env_file_path:
+                        self.logger.info("Loading environment from: %s", env_file_path)
+                        load_dotenv(env_file_path)
+                        step.detail(f"environment: {env_file_path}")
+                    else:
+                        load_dotenv()
+                        step.detail("environment: process defaults")
 
-            browser_host = self._normalize_browser_host(validated_options["host"])
+                    os.environ["GRAPH_PATH"] = str(actual_config_path)
+
+                    # Add project root to sys.path for importing graph modules
+                    sys.path.insert(0, str(actual_config_path.parent))
+
+                    # Ensure we're using the correct module path
+                    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+                browser_host = self._normalize_browser_host(validated_options["host"])
+                with timeline.step("port") as step:
+                    # Reported rather than raised: Uvicorn owns the bind, and its
+                    # own error is the authoritative one if the port is taken.
+                    if self._port_in_use(browser_host, validated_options["port"]):
+                        step.detail("already in use — Uvicorn will report the conflict")
+                    else:
+                        step.detail("available")
+
+                with timeline.step("launch") as step:
+                    self.logger.info(
+                        "Starting API with config: %s, host: %s, port: %d",
+                        actual_config_path,
+                        validated_options["host"],
+                        validated_options["port"],
+                    )
+                    launch_url = None
+                    if open_playground:
+                        launch_url = self._schedule_playground_launch(
+                            host=validated_options["host"],
+                            port=validated_options["port"],
+                            playground_base_url=playground_url,
+                        )
+                    step.detail(
+                        f"playground opens at {launch_url} once the API responds"
+                        if launch_url
+                        else f"http://{browser_host}:{validated_options['port']}"
+                    )
+
             self.output.completion_screen(
                 "Ready to serve",
                 "Agentflow runtime configured successfully",
@@ -143,18 +164,21 @@ class APICommand(BaseCommand):
             )
             return self.handle_error(server_error)
 
+    @staticmethod
+    def _port_in_use(host: str, port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.settimeout(0.2)
+            return probe.connect_ex((host, port)) == 0
+
     def _schedule_playground_launch(
         self,
         host: str,
         port: int,
         playground_base_url: str,
-    ) -> None:
+    ) -> str:
+        """Start the readiness watcher and return the URL it will open."""
         browser_host = self._normalize_browser_host(host)
         launch_url = self._build_playground_url(browser_host, port, playground_base_url)
-        self.output.info(
-            f"Playground will open at {launch_url} when the API is ready.",
-            emoji=False,
-        )
         launch_thread = threading.Thread(
             target=self._open_playground_when_ready,
             args=(launch_url, browser_host, port),
@@ -162,6 +186,7 @@ class APICommand(BaseCommand):
             name="agentflow-playground-launcher",
         )
         launch_thread.start()
+        return launch_url
 
     def _open_playground_when_ready(
         self,
@@ -179,12 +204,10 @@ class APICommand(BaseCommand):
         opened = webbrowser.open_new_tab(launch_url)
         if opened:
             self.logger.info("Opened playground URL: %s", launch_url)
-            self.output.completion_screen(
-                "Playground ready",
-                "Local API connected and browser launched",
-                details={"URL": launch_url},
-                next_steps=["Build, test, and inspect your agent in the playground."],
-            )
+            # A plain line, not a panel: this fires from the watcher thread while
+            # Uvicorn is already streaming logs, and a boxed reveal there would
+            # interleave with them.
+            self.output.success(f"Playground opened: {launch_url}")
             return
 
         message = f"Browser launch returned false. Open the playground manually: {launch_url}"

--- a/agentflow_cli/cli/commands/api.py
+++ b/agentflow_cli/cli/commands/api.py
@@ -60,6 +60,7 @@ class APICommand(BaseCommand):
             self.output.command_header(
                 "play" if open_playground else "api",
                 "Starting development server via Uvicorn. Not for production use.",
+                hint="Ctrl+C to stop the development server",
             )
 
             timeline = self.output.timeline(

--- a/agentflow_cli/cli/commands/api.py
+++ b/agentflow_cli/cli/commands/api.py
@@ -57,38 +57,40 @@ class APICommand(BaseCommand):
             Exit code
         """
         try:
-            # Print banner
-            self.output.print_banner(
-                "API (development)",
+            self.output.command_header(
+                "play" if open_playground else "api",
                 "Starting development server via Uvicorn. Not for production use.",
             )
 
-            # Validate inputs
-            validated_options = validate_cli_options(host, port, config)
+            with self.output.activity(
+                "Discovering and validating the project",
+                done="Project configuration validated",
+                spinner="aesthetic",
+            ):
+                validated_options = validate_cli_options(host, port, config)
+                config_manager = ConfigManager()
+                actual_config_path = config_manager.find_config_file(validated_options["config"])
+                config_manager.load_config(str(actual_config_path))
 
-            # Load configuration
-            config_manager = ConfigManager()
-            actual_config_path = config_manager.find_config_file(validated_options["config"])
-            # Load and validate config
-            config_manager.load_config(str(actual_config_path))
+            with self.output.activity(
+                "Loading environment and graph runtime",
+                done="Runtime environment prepared",
+                spinner="bouncingBar",
+            ):
+                env_file_path = config_manager.resolve_env_file()
+                if env_file_path:
+                    self.logger.info("Loading environment from: %s", env_file_path)
+                    load_dotenv(env_file_path)
+                else:
+                    load_dotenv()
 
-            # Load environment file if specified
-            env_file_path = config_manager.resolve_env_file()
-            if env_file_path:
-                self.logger.info("Loading environment from: %s", env_file_path)
-                load_dotenv(env_file_path)
-            else:
-                # Load default .env if it exists
-                load_dotenv()
+                os.environ["GRAPH_PATH"] = str(actual_config_path)
 
-            # Set environment variables
-            os.environ["GRAPH_PATH"] = str(actual_config_path)
+                # Add project root to sys.path for importing graph modules
+                sys.path.insert(0, str(actual_config_path.parent))
 
-            # Add project root to sys.path for importing graph modules
-            sys.path.insert(0, str(actual_config_path.parent))
-
-            # Ensure we're using the correct module path
-            sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+                # Ensure we're using the correct module path
+                sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
             self.logger.info(
                 "Starting API with config: %s, host: %s, port: %d",
@@ -104,7 +106,23 @@ class APICommand(BaseCommand):
                     playground_base_url=playground_url,
                 )
 
-            # Start the server
+            browser_host = self._normalize_browser_host(validated_options["host"])
+            self.output.completion_screen(
+                "Ready to serve",
+                "Agentflow runtime configured successfully",
+                details={
+                    "API": f"http://{browser_host}:{validated_options['port']}",
+                    "Docs": f"http://{browser_host}:{validated_options['port']}/docs",
+                    "Config": actual_config_path,
+                    "Reload": "enabled" if reload else "disabled",
+                },
+                next_steps=(
+                    ["The playground will open automatically when the API becomes reachable."]
+                    if open_playground
+                    else ["Press Ctrl+C to stop the development server."]
+                ),
+            )
+
             uvicorn.run(
                 "agentflow_cli.src.app.main:app",
                 host=validated_options["host"],
@@ -161,12 +179,17 @@ class APICommand(BaseCommand):
         opened = webbrowser.open_new_tab(launch_url)
         if opened:
             self.logger.info("Opened playground URL: %s", launch_url)
+            self.output.completion_screen(
+                "Playground ready",
+                "Local API connected and browser launched",
+                details={"URL": launch_url},
+                next_steps=["Build, test, and inspect your agent in the playground."],
+            )
             return
 
-        self.logger.warning(
-            "Browser launch returned false. Open the playground manually: %s",
-            launch_url,
-        )
+        message = f"Browser launch returned false. Open the playground manually: {launch_url}"
+        self.logger.warning(message)
+        self.output.warning(message)
 
     def _wait_for_server(
         self,

--- a/agentflow_cli/cli/commands/audit.py
+++ b/agentflow_cli/cli/commands/audit.py
@@ -1,4 +1,24 @@
-"""Environment and project diagnostics for the Agentflow CLI."""
+"""Environment and project audit for the Agentflow CLI.
+
+Backs ``agentflow audit``: a read-only pass over everything that has to be true
+before ``agentflow dev``, ``eval``, or ``build`` can work in the current
+directory. Nothing here mutates the project, the environment, or the user
+configuration, so it is always safe to run.
+
+Each check returns a :class:`Diagnostic` with one of three statuses:
+
+``pass``
+    The requirement is satisfied.
+``warn``
+    Not fatal for every workflow, but likely to surprise you. A missing
+    ``agentflow.json`` is fine until you run ``agentflow dev``; a busy port is
+    fine until you try to bind it.
+``fail``
+    A hard requirement is unmet and commands that depend on it will not run.
+
+The command's exit code is the aggregate of those statuses (see
+:meth:`AuditCommand.execute`), which is what makes it usable as a CI gate.
+"""
 
 from __future__ import annotations
 
@@ -18,18 +38,51 @@ from agentflow_cli.cli.constants import DEFAULT_PORT
 
 @dataclass(frozen=True)
 class Diagnostic:
+    """One audit result.
+
+    Attributes:
+        name: Human-readable label for the thing that was checked.
+        status: One of ``"pass"``, ``"warn"``, or ``"fail"``.
+        detail: Supporting evidence — a version, a path, or an error message.
+    """
+
     name: str
     status: str
     detail: str
 
 
-class DoctorCommand(BaseCommand):
-    """Inspect the local CLI, core package, project config, and default port."""
+class AuditCommand(BaseCommand):
+    """Audit the local CLI, core package, project config, and default port.
+
+    Runs six checks in a fixed order and reports them twice: live, through the
+    step timeline, and again as a summary table once every check has finished.
+
+    ============  ==========================================================
+    Check         What it asserts
+    ============  ==========================================================
+    python        The interpreter running the CLI (reported, never failed).
+    cli           ``10xscale-agentflow-cli`` is installed and resolvable.
+    core          ``10xscale-agentflow`` is installed and resolvable.
+    evaluation    The installed core exposes the evaluation symbols that
+                  ``agentflow eval`` imports, catching a CLI/core version
+                  skew before it becomes an ImportError mid-run.
+    config        ``agentflow.json`` exists here, parses, and declares an
+                  ``agent`` key in ``module:attribute`` form.
+    port          The default API port is free to bind.
+    ============  ==========================================================
+    """
 
     def execute(self, **kwargs: Any) -> int:
+        """Run every check and report the outcome.
+
+        Returns:
+            ``1`` if any check failed, otherwise ``0`` — warnings are surfaced
+            but do not fail the run, so ``agentflow audit`` can gate CI on
+            hard breakage without tripping on an absent project config.
+        """
         self.output.command_header(
-            "doctor",
-            "Checking the current Agentflow development environment.",
+            "audit",
+            "Auditing the current Agentflow development environment.",
             color="cyan",
         )
 
@@ -48,7 +101,7 @@ class DoctorCommand(BaseCommand):
 
         diagnostics: list[Diagnostic] = []
         timeline = self.output.timeline(
-            "Running environment checks",
+            "Running environment audit",
             steps=tuple((key, title) for key, title, _ in checks),
         )
         with timeline:
@@ -61,7 +114,7 @@ class DoctorCommand(BaseCommand):
         self.output.print_table(
             ["Check", "Status", "Details"],
             [[item.name, self._status_label(item.status), item.detail] for item in diagnostics],
-            title="Diagnostics",
+            title="Audit results",
         )
 
         failures = [item for item in diagnostics if item.status == "fail"]
@@ -81,6 +134,7 @@ class DoctorCommand(BaseCommand):
 
     @staticmethod
     def _package_check(distribution: str) -> Diagnostic:
+        """Report the installed version of ``distribution``, or fail if absent."""
         try:
             installed = version(distribution)
         except PackageNotFoundError:
@@ -89,6 +143,12 @@ class DoctorCommand(BaseCommand):
 
     @staticmethod
     def _evaluation_api_check() -> Diagnostic:
+        """Fail when the installed core lacks the symbols ``agentflow eval`` needs.
+
+        This is the CLI/core version-skew check: both packages can be installed
+        and still be incompatible, and without this the mismatch only surfaces
+        as an ImportError partway through an evaluation run.
+        """
         try:
             evaluation = importlib.import_module("agentflow.qa.evaluation")
         except ImportError as exc:
@@ -106,6 +166,13 @@ class DoctorCommand(BaseCommand):
 
     @staticmethod
     def _config_check() -> Diagnostic:
+        """Validate ``agentflow.json`` in the working directory.
+
+        Warns rather than fails when the file is absent, because the audit is
+        also useful outside a project directory. A file that exists but cannot
+        be parsed, or that omits a ``module:attribute`` ``agent`` key, is a
+        hard failure.
+        """
         config_path = Path.cwd() / "agentflow.json"
         if not config_path.exists():
             return Diagnostic("Project config", "warn", f"not found at {config_path}")
@@ -120,6 +187,11 @@ class DoctorCommand(BaseCommand):
 
     @staticmethod
     def _port_check(port: int) -> Diagnostic:
+        """Warn when ``port`` on loopback already has a listener.
+
+        A short connect probe, not a bind attempt, so the audit never steals
+        the port from a server that is about to start.
+        """
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.settimeout(0.2)
             if sock.connect_ex(("127.0.0.1", port)) == 0:
@@ -128,4 +200,5 @@ class DoctorCommand(BaseCommand):
 
     @staticmethod
     def _status_label(status: str) -> str:
+        """Render a status as the uppercase token used in the timeline and table."""
         return {"pass": "PASS", "warn": "WARN", "fail": "FAIL"}[status]

--- a/agentflow_cli/cli/commands/build.py
+++ b/agentflow_cli/cli/commands/build.py
@@ -51,76 +51,85 @@ class BuildCommand(BaseCommand):
                 color="yellow",
             )
 
-            # Validate inputs
-            validated_port = Validator.validate_port(port)
-            validated_python_version = Validator.validate_python_version(python_version)
-            validated_service_name = Validator.validate_service_name(service_name)
-            output_path = Validator.validate_path(output_file)
-
-            current_dir = Path.cwd()
-
-            # Check if Dockerfile already exists
-            if output_path.exists() and not force:
-                raise FileOperationError(
-                    f"Dockerfile already exists at {output_path}. Use --force to overwrite.",
-                    file_path=str(output_path),
-                )
-
-            # Discover requirements files
-            requirements_files, requirements_file = self._discover_requirements(current_dir)
-
-            with self.output.activity(
-                "Generating container assets",
-                done="Container assets generated",
-                spinner="material",
-            ):
-                dockerfile_content = generate_dockerfile_content(
-                    python_version=validated_python_version,
-                    port=validated_port,
-                    requirements_file=requirements_file,
-                    has_requirements=bool(requirements_files),
-                    omit_cmd=docker_compose,
-                )
-                self._write_dockerfile(output_path, dockerfile_content)
-            self.output.success(f"Successfully generated Dockerfile at {output_path}")
-
-            # Write .dockerignore in the same directory
-            dockerignore_path = output_path.parent / ".dockerignore"
-            if not dockerignore_path.exists() or force:
-                try:
-                    dockerignore_content = generate_dockerignore_content()
-                    dockerignore_path.write_text(dockerignore_content, encoding="utf-8")
-                    self.output.success(
-                        f"Successfully generated .dockerignore at {dockerignore_path}"
-                    )
-                except Exception as e:
-                    self.output.warning(f"Could not generate .dockerignore: {e}")
-
-            # Show requirements info
-            if requirements_files:
-                self.output.info(f"Using requirements file: {requirements_files[0]}")
-            else:
-                self.output.warning(
-                    "No requirements.txt found - will install agentflow-cli from PyPI"
-                )
-
-            # Generate docker-compose.yml if requested
+            steps: list[tuple[str, str]] = [
+                ("validate", "Validating build options"),
+                ("sources", "Discovering project sources"),
+                ("dockerfile", "Generating Dockerfile"),
+                ("dockerignore", "Generating .dockerignore"),
+            ]
             if docker_compose:
-                self._write_docker_compose(
-                    force=force, service_name=validated_service_name, port=validated_port
-                )
-
-            # Generate a Kubernetes manifest if requested
+                steps.append(("compose", "Generating docker-compose.yml"))
             if k8s:
-                self._write_k8s_manifest(
-                    force=force, service_name=validated_service_name, port=validated_port
-                )
+                steps.append(("k8s", "Generating k8s.yaml"))
 
             generated = ["Dockerfile", ".dockerignore"]
-            if docker_compose:
-                generated.append("docker-compose.yml")
-            if k8s:
-                generated.append("k8s.yaml")
+            timeline = self.output.timeline("Assembling deployment assets", steps=tuple(steps))
+            with timeline:
+                with timeline.step("validate") as step:
+                    validated_port = Validator.validate_port(port)
+                    validated_python_version = Validator.validate_python_version(python_version)
+                    validated_service_name = Validator.validate_service_name(service_name)
+                    output_path = Validator.validate_path(output_file)
+                    if output_path.exists() and not force:
+                        raise FileOperationError(
+                            f"Dockerfile already exists at {output_path}. "
+                            "Use --force to overwrite.",
+                            file_path=str(output_path),
+                        )
+                    step.detail(
+                        f"python {validated_python_version} · port {validated_port} · "
+                        f"service {validated_service_name}"
+                    )
+
+                with timeline.step("sources") as step:
+                    requirements_files, requirements_file = self._discover_requirements(Path.cwd())
+                    step.detail(
+                        f"requirements: {requirements_files[0]}"
+                        if requirements_files
+                        else "no requirements.txt — installing agentflow-cli from PyPI"
+                    )
+
+                with timeline.step("dockerfile") as step:
+                    dockerfile_content = generate_dockerfile_content(
+                        python_version=validated_python_version,
+                        port=validated_port,
+                        requirements_file=requirements_file,
+                        has_requirements=bool(requirements_files),
+                        omit_cmd=docker_compose,
+                    )
+                    self._write_dockerfile(output_path, dockerfile_content)
+                    step.detail(str(output_path))
+
+                dockerignore_path = output_path.parent / ".dockerignore"
+                with timeline.step("dockerignore") as step:
+                    if dockerignore_path.exists() and not force:
+                        step.skip(f"{dockerignore_path} already exists")
+                    else:
+                        dockerignore_path.write_text(
+                            generate_dockerignore_content(), encoding="utf-8"
+                        )
+                        step.detail(str(dockerignore_path))
+
+                if docker_compose:
+                    with timeline.step("compose") as step:
+                        self._write_docker_compose(
+                            force=force,
+                            service_name=validated_service_name,
+                            port=validated_port,
+                        )
+                        generated.append("docker-compose.yml")
+                        step.detail("docker-compose.yml")
+
+                if k8s:
+                    with timeline.step("k8s") as step:
+                        self._write_k8s_manifest(
+                            force=force,
+                            service_name=validated_service_name,
+                            port=validated_port,
+                        )
+                        generated.append("k8s.yaml")
+                        step.detail("k8s.yaml")
+
             self.output.completion_screen(
                 "Build assets ready",
                 "Deployment files generated successfully",
@@ -216,7 +225,6 @@ class BuildCommand(BaseCommand):
 
         try:
             manifest_path.write_text(content, encoding="utf-8")
-            self.output.success(f"Generated k8s.yaml at {manifest_path}")
         except OSError as e:
             raise FileOperationError(
                 f"Failed to write k8s.yaml: {e}", file_path=str(manifest_path)
@@ -245,7 +253,6 @@ class BuildCommand(BaseCommand):
 
         try:
             compose_path.write_text(compose_content, encoding="utf-8")
-            self.output.success(f"Generated docker-compose.yml at {compose_path}")
         except OSError as e:
             raise FileOperationError(
                 f"Failed to write docker-compose.yml: {e}", file_path=str(compose_path)

--- a/agentflow_cli/cli/commands/build.py
+++ b/agentflow_cli/cli/commands/build.py
@@ -3,8 +3,6 @@
 from pathlib import Path
 from typing import Any
 
-import typer
-
 from agentflow_cli.cli.commands import BaseCommand
 from agentflow_cli.cli.constants import DEFAULT_PORT, DEFAULT_PYTHON_VERSION, DEFAULT_SERVICE_NAME
 from agentflow_cli.cli.core.validation import Validator
@@ -241,8 +239,6 @@ class BuildCommand(BaseCommand):
         Args:
             docker_compose: Whether docker-compose was generated
         """
-        self.output.info("\n🚀 Next steps:")
-
         if docker_compose:
             steps = [
                 "Review the generated Dockerfile and docker-compose.yml",
@@ -258,10 +254,12 @@ class BuildCommand(BaseCommand):
                 "Access your API at: http://localhost:8000",
             ]
 
-        for i, step in enumerate(steps, 1):
-            typer.echo(f"{i}. {step}")
+        self.output.print_list(
+            [f"{index}. {step}" for index, step in enumerate(steps, 1)],
+            title="Next steps",
+            bullet="→",
+        )
 
-        self.output.info("\n💡 For production deployment, consider:")
         production_tips = [
             "Using a multi-stage build to reduce image size",
             "Setting up proper environment variables",
@@ -269,5 +267,8 @@ class BuildCommand(BaseCommand):
             "Using a reverse proxy like nginx",
         ]
 
-        for tip in production_tips:
-            typer.echo(f"   • {tip}")
+        self.output.print_list(
+            production_tips,
+            title="Production considerations",
+            bullet="•",
+        )

--- a/agentflow_cli/cli/commands/build.py
+++ b/agentflow_cli/cli/commands/build.py
@@ -45,9 +45,8 @@ class BuildCommand(BaseCommand):
             Exit code
         """
         try:
-            # Print banner
-            self.output.print_banner(
-                "Build",
+            self.output.command_header(
+                "build",
                 "Generate Dockerfile (and optional docker-compose.yml) for production image",
                 color="yellow",
             )
@@ -70,17 +69,19 @@ class BuildCommand(BaseCommand):
             # Discover requirements files
             requirements_files, requirements_file = self._discover_requirements(current_dir)
 
-            # Generate Dockerfile content
-            dockerfile_content = generate_dockerfile_content(
-                python_version=validated_python_version,
-                port=validated_port,
-                requirements_file=requirements_file,
-                has_requirements=bool(requirements_files),
-                omit_cmd=docker_compose,
-            )
-
-            # Write Dockerfile
-            self._write_dockerfile(output_path, dockerfile_content)
+            with self.output.activity(
+                "Generating container assets",
+                done="Container assets generated",
+                spinner="material",
+            ):
+                dockerfile_content = generate_dockerfile_content(
+                    python_version=validated_python_version,
+                    port=validated_port,
+                    requirements_file=requirements_file,
+                    has_requirements=bool(requirements_files),
+                    omit_cmd=docker_compose,
+                )
+                self._write_dockerfile(output_path, dockerfile_content)
             self.output.success(f"Successfully generated Dockerfile at {output_path}")
 
             # Write .dockerignore in the same directory
@@ -115,8 +116,25 @@ class BuildCommand(BaseCommand):
                     force=force, service_name=validated_service_name, port=validated_port
                 )
 
-            # Show next steps
-            self._show_next_steps(docker_compose)
+            generated = ["Dockerfile", ".dockerignore"]
+            if docker_compose:
+                generated.append("docker-compose.yml")
+            if k8s:
+                generated.append("k8s.yaml")
+            self.output.completion_screen(
+                "Build assets ready",
+                "Deployment files generated successfully",
+                details={
+                    "Files": ", ".join(generated),
+                    "Service": validated_service_name,
+                    "Port": validated_port,
+                },
+                next_steps=(
+                    ["docker compose up --build"]
+                    if docker_compose
+                    else [f"docker build -t {validated_service_name} ."]
+                ),
+            )
 
             return 0
 

--- a/agentflow_cli/cli/commands/demo.py
+++ b/agentflow_cli/cli/commands/demo.py
@@ -15,6 +15,21 @@ class DemoCommand(BaseCommand):
     _STYLES = ("typing", "network", "init", "build", "eval")
     _ALIASES = {"play": "typing", "api": "network"}
 
+    _SUBTITLES = {
+        "typing": "Full-screen Agentflow identity and workspace transition",
+        "network": "Live agent network and playground connection",
+        "init": "Project scaffold assembly",
+        "build": "Container delivery pipeline",
+        "eval": "Evaluation scan and completion states",
+    }
+    _COMMAND_NAMES = {
+        "typing": "typing",
+        "network": "api",
+        "init": "init",
+        "build": "build",
+        "eval": "eval",
+    }
+
     def execute(self, style: str = "all", **kwargs: Any) -> int:
         normalized = self._ALIASES.get(style.strip().lower(), style.strip().lower())
         if normalized != "all" and normalized not in self._STYLES:
@@ -27,31 +42,11 @@ class DemoCommand(BaseCommand):
             )
 
         selected = self._STYLES if normalized == "all" else (normalized,)
-        subtitles = {
-            "typing": "Full-screen Agentflow identity and workspace transition",
-            "network": "Live agent network and playground connection",
-            "init": "Project scaffold assembly",
-            "build": "Container delivery pipeline",
-            "eval": "Evaluation scan and completion states",
-        }
-        command_names = {
-            "typing": "typing",
-            "network": "api",
-            "init": "init",
-            "build": "build",
-            "eval": "eval",
-        }
         for theme in selected:
-            self.output.command_header(command_names[theme], subtitles[theme])
+            self.output.command_header(self._COMMAND_NAMES[theme], self._SUBTITLES[theme])
 
-        stages = (
-            ("Resolving graph topology", "Graph topology resolved", "aesthetic"),
-            ("Assembling runtime pipeline", "Runtime pipeline assembled", "bouncingBar"),
-            ("Connecting developer experience", "Developer experience connected", "moon"),
-        )
-        for message, done, spinner in stages:
-            with self.output.activity(message, done=done, spinner=spinner):
-                time.sleep(0.35)
+        self._preview_timeline()
+        self._preview_progress()
 
         self.output.completion_screen(
             "Animation showcase",
@@ -64,6 +59,35 @@ class DemoCommand(BaseCommand):
             next_steps=[
                 "Run `agentflow play` to see the network theme in a real workflow.",
                 "Use `agentflow --no-animation COMMAND` for static accessible output.",
+                "Use `agentflow --fullscreen COMMAND` to hold a dedicated screen.",
             ],
         )
         return 0
+
+    def _preview_timeline(self) -> None:
+        stages = (
+            ("topology", "Resolving graph topology", "3 nodes, 2 edges"),
+            ("pipeline", "Assembling runtime pipeline", "checkpointer + store bound"),
+            ("experience", "Connecting developer experience", "playground reachable"),
+        )
+        timeline = self.output.timeline(
+            "Timeline preview",
+            steps=tuple((key, title) for key, title, _ in stages),
+        )
+        with timeline:
+            for key, _title, detail in stages:
+                with timeline.step(key) as step:
+                    time.sleep(0.35)
+                    step.detail(detail)
+
+    def _preview_progress(self) -> None:
+        samples = (
+            ("weather_eval::forecast_tokyo", "passed"),
+            ("weather_eval::forecast_oslo", "passed"),
+            ("weather_eval::unknown_city", "failed"),
+            ("weather_eval::rate_limited", "passed"),
+        )
+        with self.output.progress_run("Progress preview", total=len(samples)) as progress:
+            for label, status in samples:
+                time.sleep(0.18)
+                progress.record(label, status=status, detail="0.42s")

--- a/agentflow_cli/cli/commands/demo.py
+++ b/agentflow_cli/cli/commands/demo.py
@@ -1,0 +1,69 @@
+"""Safe interactive showcase for Agentflow terminal motion."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from agentflow_cli.cli.commands import BaseCommand
+from agentflow_cli.cli.exceptions import ValidationError
+
+
+class DemoCommand(BaseCommand):
+    """Preview command-specific animations without external side effects."""
+
+    _STYLES = ("typing", "network", "init", "build", "eval")
+    _ALIASES = {"play": "typing", "api": "network"}
+
+    def execute(self, style: str = "all", **kwargs: Any) -> int:
+        normalized = self._ALIASES.get(style.strip().lower(), style.strip().lower())
+        if normalized != "all" and normalized not in self._STYLES:
+            return self.handle_error(
+                ValidationError(
+                    f"Unknown animation style '{style}'. "
+                    f"Choose all, {', '.join(self._STYLES)}.",
+                    field="style",
+                )
+            )
+
+        selected = self._STYLES if normalized == "all" else (normalized,)
+        subtitles = {
+            "typing": "Full-screen Agentflow identity and workspace transition",
+            "network": "Live agent network and playground connection",
+            "init": "Project scaffold assembly",
+            "build": "Container delivery pipeline",
+            "eval": "Evaluation scan and completion states",
+        }
+        command_names = {
+            "typing": "typing",
+            "network": "api",
+            "init": "init",
+            "build": "build",
+            "eval": "eval",
+        }
+        for theme in selected:
+            self.output.command_header(command_names[theme], subtitles[theme])
+
+        stages = (
+            ("Resolving graph topology", "Graph topology resolved", "aesthetic"),
+            ("Assembling runtime pipeline", "Runtime pipeline assembled", "bouncingBar"),
+            ("Connecting developer experience", "Developer experience connected", "moon"),
+        )
+        for message, done, spinner in stages:
+            with self.output.activity(message, done=done, spinner=spinner):
+                time.sleep(0.35)
+
+        self.output.completion_screen(
+            "Animation showcase",
+            "All preview states rendered successfully",
+            details={
+                "Themes": ", ".join(selected),
+                "Side effects": "none",
+                "Fallback": "automatic for CI, pipes, and JSON",
+            },
+            next_steps=[
+                "Run `agentflow play` to see the network theme in a real workflow.",
+                "Use `agentflow --no-animation COMMAND` for static accessible output.",
+            ],
+        )
+        return 0

--- a/agentflow_cli/cli/commands/doctor.py
+++ b/agentflow_cli/cli/commands/doctor.py
@@ -1,0 +1,111 @@
+"""Environment and project diagnostics for the Agentflow CLI."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import socket
+import sys
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+from agentflow_cli.cli.commands import BaseCommand
+from agentflow_cli.cli.constants import DEFAULT_PORT
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    name: str
+    status: str
+    detail: str
+
+
+class DoctorCommand(BaseCommand):
+    """Inspect the local CLI, core package, project config, and default port."""
+
+    def execute(self, **kwargs: Any) -> int:
+        diagnostics = [
+            Diagnostic("Python", "pass", sys.version.split()[0]),
+            self._package_check("10xscale-agentflow-cli"),
+            self._package_check("10xscale-agentflow"),
+            self._evaluation_api_check(),
+            self._config_check(),
+            self._port_check(DEFAULT_PORT),
+        ]
+        self.output.print_banner(
+            "Doctor",
+            "Checking the current Agentflow development environment.",
+            color="cyan",
+        )
+        self.output.print_table(
+            ["Check", "Status", "Details"],
+            [
+                [item.name, self._status_label(item.status), item.detail]
+                for item in diagnostics
+            ],
+            title="Diagnostics",
+        )
+
+        failures = [item for item in diagnostics if item.status == "fail"]
+        warnings = [item for item in diagnostics if item.status == "warn"]
+        if failures:
+            self.output.error(f"{len(failures)} required check(s) failed.")
+            return 1
+        if warnings:
+            self.output.warning(f"{len(warnings)} check(s) need attention.")
+        else:
+            self.output.success("Environment is ready.")
+        return 0
+
+    @staticmethod
+    def _package_check(distribution: str) -> Diagnostic:
+        try:
+            installed = version(distribution)
+        except PackageNotFoundError:
+            return Diagnostic(distribution, "fail", "not installed")
+        return Diagnostic(distribution, "pass", installed)
+
+    @staticmethod
+    def _evaluation_api_check() -> Diagnostic:
+        try:
+            evaluation = importlib.import_module("agentflow.qa.evaluation")
+        except ImportError as exc:
+            return Diagnostic("Evaluation API", "fail", str(exc))
+
+        required = ("CriteriaConfig", "CriterionConfig", "EvalConfig")
+        missing = [name for name in required if not hasattr(evaluation, name)]
+        if missing:
+            return Diagnostic(
+                "Evaluation API",
+                "fail",
+                "core package is missing: " + ", ".join(missing),
+            )
+        return Diagnostic("Evaluation API", "pass", "compatible")
+
+    @staticmethod
+    def _config_check() -> Diagnostic:
+        config_path = Path.cwd() / "agentflow.json"
+        if not config_path.exists():
+            return Diagnostic("Project config", "warn", f"not found at {config_path}")
+        try:
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return Diagnostic("Project config", "fail", str(exc))
+        agent = data.get("agent")
+        if not isinstance(agent, str) or ":" not in agent:
+            return Diagnostic("Project config", "fail", "'agent' must be a module:attribute string")
+        return Diagnostic("Project config", "pass", str(config_path))
+
+    @staticmethod
+    def _port_check(port: int) -> Diagnostic:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.2)
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                return Diagnostic(f"Port {port}", "warn", "already in use")
+        return Diagnostic(f"Port {port}", "pass", "available")
+
+    @staticmethod
+    def _status_label(status: str) -> str:
+        return {"pass": "PASS", "warn": "WARN", "fail": "FAIL"}[status]

--- a/agentflow_cli/cli/commands/doctor.py
+++ b/agentflow_cli/cli/commands/doctor.py
@@ -6,6 +6,7 @@ import importlib
 import json
 import socket
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -26,25 +27,40 @@ class DoctorCommand(BaseCommand):
     """Inspect the local CLI, core package, project config, and default port."""
 
     def execute(self, **kwargs: Any) -> int:
-        diagnostics = [
-            Diagnostic("Python", "pass", sys.version.split()[0]),
-            self._package_check("10xscale-agentflow-cli"),
-            self._package_check("10xscale-agentflow"),
-            self._evaluation_api_check(),
-            self._config_check(),
-            self._port_check(DEFAULT_PORT),
-        ]
         self.output.command_header(
             "doctor",
             "Checking the current Agentflow development environment.",
             color="cyan",
         )
+
+        checks: tuple[tuple[str, str, Callable[[], Diagnostic]], ...] = (
+            (
+                "python",
+                "Python interpreter",
+                lambda: Diagnostic("Python", "pass", sys.version.split()[0]),
+            ),
+            ("cli", "CLI package", lambda: self._package_check("10xscale-agentflow-cli")),
+            ("core", "Core framework", lambda: self._package_check("10xscale-agentflow")),
+            ("evaluation", "Evaluation API", self._evaluation_api_check),
+            ("config", "Project configuration", self._config_check),
+            ("port", f"Port {DEFAULT_PORT}", lambda: self._port_check(DEFAULT_PORT)),
+        )
+
+        diagnostics: list[Diagnostic] = []
+        timeline = self.output.timeline(
+            "Running environment checks",
+            steps=tuple((key, title) for key, title, _ in checks),
+        )
+        with timeline:
+            for key, _title, run in checks:
+                with timeline.step(key) as step:
+                    result = run()
+                    diagnostics.append(result)
+                    step.detail(f"{self._status_label(result.status)}  {result.detail}")
+
         self.output.print_table(
             ["Check", "Status", "Details"],
-            [
-                [item.name, self._status_label(item.status), item.detail]
-                for item in diagnostics
-            ],
+            [[item.name, self._status_label(item.status), item.detail] for item in diagnostics],
             title="Diagnostics",
         )
 

--- a/agentflow_cli/cli/commands/doctor.py
+++ b/agentflow_cli/cli/commands/doctor.py
@@ -34,8 +34,8 @@ class DoctorCommand(BaseCommand):
             self._config_check(),
             self._port_check(DEFAULT_PORT),
         ]
-        self.output.print_banner(
-            "Doctor",
+        self.output.command_header(
+            "doctor",
             "Checking the current Agentflow development environment.",
             color="cyan",
         )
@@ -56,7 +56,11 @@ class DoctorCommand(BaseCommand):
         if warnings:
             self.output.warning(f"{len(warnings)} check(s) need attention.")
         else:
-            self.output.success("Environment is ready.")
+            self.output.completion_screen(
+                "Environment ready",
+                "All required Agentflow checks passed",
+                details={"Checks": len(diagnostics), "Project": Path.cwd()},
+            )
         return 0
 
     @staticmethod

--- a/agentflow_cli/cli/commands/eval.py
+++ b/agentflow_cli/cli/commands/eval.py
@@ -503,9 +503,7 @@ class EvalCommand(BaseCommand):
             seen.add(pc.file_name)
 
             if isinstance(pc, _PendingSimulation):
-                blocks.append(
-                    f"Criteria  {pc.file_name}  (source: user-simulator goals)"
-                )
+                blocks.append(f"Criteria  {pc.file_name}  (source: user-simulator goals)")
                 continue
 
             source = pc.config_source
@@ -650,9 +648,7 @@ class EvalCommand(BaseCommand):
                 detail=self._case_detail(result),
             )
 
-        title = "Running evaluation cases" + (
-            f" ({max_concurrency} at a time)" if parallel else ""
-        )
+        title = "Running evaluation cases" + (f" ({max_concurrency} at a time)" if parallel else "")
 
         if not parallel:
             results: list[tuple[str, str, str, EvalCaseResult]] = []

--- a/agentflow_cli/cli/commands/eval.py
+++ b/agentflow_cli/cli/commands/eval.py
@@ -525,25 +525,19 @@ class EvalCommand(BaseCommand):
     # Progress printing
     # ------------------------------------------------------------------
 
-    def _print_case_progress(
-        self,
-        file_name: str,
-        case_name: str,
-        result: EvalCaseResult,
-        index: int,
-        total: int,
-    ) -> None:
-        status = "PASSED" if result.passed else ("ERROR" if result.is_error else "FAILED")
-        duration = f"{result.duration_seconds:.2f}s"
-        label = f"{file_name}::{case_name}"
+    @staticmethod
+    def _case_status(result: EvalCaseResult) -> str:
+        if result.passed:
+            return "passed"
+        return "error" if result.is_error else "failed"
+
+    @staticmethod
+    def _case_detail(result: EvalCaseResult) -> str:
+        detail = f"{result.duration_seconds:.2f}s"
         tok = getattr(result, "token_usage", None)
-        tok_str = ""
         if tok and (tok.input_tokens or tok.output_tokens):
-            tok_str = f"  in={tok.input_tokens} out={tok.output_tokens}"
-        self.output.info(
-            f"[{index:3d}/{total}] {label}  {status}  {duration}{tok_str}",
-            emoji=False,
-        )
+            detail += f"  in={tok.input_tokens} out={tok.output_tokens}"
+        return detail
 
     # ------------------------------------------------------------------
     # Flat pool execution — single asyncio event loop for all cases
@@ -560,7 +554,6 @@ class EvalCommand(BaseCommand):
         Returns list of (file_name, eval_set_id, eval_set_name, EvalCaseResult).
         """
         total = len(pending)
-        completed = 0
 
         async def _run_case(pc: _PendingCase) -> tuple[str, str, str, EvalCaseResult]:
             local_collector = TrajectoryCollector(
@@ -649,16 +642,25 @@ class EvalCommand(BaseCommand):
                 return await _run_simulation(item)
             return await _run_case(item)
 
+        def _record(progress: Any, quad: tuple[str, str, str, EvalCaseResult]) -> None:
+            file_name, _, _, result = quad
+            progress.record(
+                f"{file_name}::{result.name or result.eval_id}",
+                status=self._case_status(result),
+                detail=self._case_detail(result),
+            )
+
+        title = "Running evaluation cases" + (
+            f" ({max_concurrency} at a time)" if parallel else ""
+        )
+
         if not parallel:
             results: list[tuple[str, str, str, EvalCaseResult]] = []
-            for item in pending:
-                quad = await _dispatch(item)
-                completed += 1
-                file_name, _, _, result = quad
-                self._print_case_progress(
-                    file_name, result.name or result.eval_id, result, completed, total
-                )
-                results.append(quad)
+            with self.output.progress_run(title, total=total) as progress:
+                for item in pending:
+                    quad = await _dispatch(item)
+                    _record(progress, quad)
+                    results.append(quad)
             return results
 
         semaphore = asyncio.Semaphore(max_concurrency)
@@ -670,15 +672,12 @@ class EvalCommand(BaseCommand):
                 return await _dispatch(item)
 
         output_results: list[tuple[str, str, str, EvalCaseResult]] = []
-        tasks = [asyncio.create_task(_run_one(item)) for item in pending]
-        for coro in asyncio.as_completed(tasks):
-            quad = await coro
-            completed += 1
-            file_name, _, _, result = quad
-            self._print_case_progress(
-                file_name, result.name or result.eval_id, result, completed, total
-            )
-            output_results.append(quad)
+        with self.output.progress_run(title, total=total) as progress:
+            tasks = [asyncio.create_task(_run_one(item)) for item in pending]
+            for coro in asyncio.as_completed(tasks):
+                quad = await coro
+                _record(progress, quad)
+                output_results.append(quad)
 
         return output_results
 

--- a/agentflow_cli/cli/commands/eval.py
+++ b/agentflow_cli/cli/commands/eval.py
@@ -424,7 +424,7 @@ class EvalCommand(BaseCommand):
             source = "built-in defaults"
             criteria = self._default_config().criteria
 
-        print(f"Criteria  source: {source}", flush=True)  # noqa: T201
+        lines = [f"Criteria  source: {source}"]
         for name in criteria.model_fields:
             cfg = getattr(criteria, name)
             if cfg is None:
@@ -436,8 +436,8 @@ class EvalCommand(BaseCommand):
                 parts.append(f"judge={cfg.judge_model}")
             if cfg.num_samples and cfg.num_samples != 1:
                 parts.append(f"samples={cfg.num_samples}")
-            print(f"  {name:<40} {'  '.join(parts)}", flush=True)  # noqa: T201
-        print("", flush=True)  # noqa: T201
+            lines.append(f"  {name:<40} {'  '.join(parts)}")
+        self.output.info("\n".join(lines), emoji=False)
 
     def _criteria_rows(self, config: EvalConfig) -> list[tuple[str, str, dict[str, Any]]]:
         """Return (name, human_summary, machine_dict) for each active criterion."""
@@ -496,28 +496,30 @@ class EvalCommand(BaseCommand):
         (per-file > confeval.py > built-in defaults).
         """
         seen: set[str] = set()
+        blocks: list[str] = []
         for pc in pending:
             if pc.file_name in seen:
                 continue
             seen.add(pc.file_name)
 
             if isinstance(pc, _PendingSimulation):
-                print(  # noqa: T201
-                    f"Criteria  {pc.file_name}  (source: user-simulator goals)", flush=True
+                blocks.append(
+                    f"Criteria  {pc.file_name}  (source: user-simulator goals)"
                 )
-                print("", flush=True)  # noqa: T201
                 continue
 
             source = pc.config_source
             if source == "confeval.py" and confeval_path:
                 source = str(confeval_path)
-            print(f"Criteria  {pc.file_name}  (source: {source})", flush=True)  # noqa: T201
+            lines = [f"Criteria  {pc.file_name}  (source: {source})"]
             rows = self._criteria_rows(pc.config)
             if not rows:
-                print("  (no active criteria)", flush=True)  # noqa: T201
+                lines.append("  (no active criteria)")
             for name, summary, _ in rows:
-                print(f"  {name:<40} {summary}", flush=True)  # noqa: T201
-            print("", flush=True)  # noqa: T201
+                lines.append(f"  {name:<40} {summary}")
+            blocks.append("\n".join(lines))
+        if blocks:
+            self.output.info("\n\n".join(blocks), emoji=False)
 
     # ------------------------------------------------------------------
     # Progress printing
@@ -534,12 +536,14 @@ class EvalCommand(BaseCommand):
         status = "PASSED" if result.passed else ("ERROR" if result.is_error else "FAILED")
         duration = f"{result.duration_seconds:.2f}s"
         label = f"{file_name}::{case_name}"
-        status_colored = f"\033[32m{status}\033[0m" if result.passed else f"\033[31m{status}\033[0m"
         tok = getattr(result, "token_usage", None)
         tok_str = ""
         if tok and (tok.input_tokens or tok.output_tokens):
             tok_str = f"  in={tok.input_tokens} out={tok.output_tokens}"
-        print(f"[{index:3d}/{total}] {label}  {status_colored}  {duration}{tok_str}", flush=True)  # noqa: T201
+        self.output.info(
+            f"[{index:3d}/{total}] {label}  {status}  {duration}{tok_str}",
+            emoji=False,
+        )
 
     # ------------------------------------------------------------------
     # Flat pool execution — single asyncio event loop for all cases
@@ -892,7 +896,7 @@ class EvalCommand(BaseCommand):
                     self.output.warning(f"Reporter error [{name}]: {err}")
 
             if open_report and report_result.html_path:
-                webbrowser.open(Path(report_result.html_path).as_uri())
+                webbrowser.open(Path(report_result.html_path).resolve().as_uri())
 
         summary = merged.summary
         self.output.info(

--- a/agentflow_cli/cli/commands/eval.py
+++ b/agentflow_cli/cli/commands/eval.py
@@ -818,8 +818,8 @@ class EvalCommand(BaseCommand):
             parts.append(f"{n_cases} eval case(s)")
         if n_sims:
             parts.append(f"{n_sims} simulation scenario(s)")
-        self.output.print_banner(
-            "Eval",
+        self.output.command_header(
+            "eval",
             f"Found {', '.join(parts)} across {n_files} file(s) in {target_path}",
         )
 

--- a/agentflow_cli/cli/commands/init.py
+++ b/agentflow_cli/cli/commands/init.py
@@ -3,6 +3,7 @@
 import contextlib
 import json
 import re
+from collections.abc import Callable
 from pathlib import Path
 from string import Template
 from typing import Any
@@ -96,8 +97,7 @@ class InitCommand(BaseCommand):
                 planned = [
                     str(src.relative_to(template_dir))
                     for src in sorted(template_dir.rglob("*"))
-                    if src.is_file()
-                    and not self._should_skip(src, template_dir, context, is_prod)
+                    if src.is_file() and not self._should_skip(src, template_dir, context, is_prod)
                 ]
                 if "agentflow.json" not in planned:
                     planned.append("agentflow.json")
@@ -105,27 +105,41 @@ class InitCommand(BaseCommand):
                 self.output.info("Dry run complete; no files were written.", emoji=False)
                 return 0
 
-            with self.output.activity(
-                "Scaffolding project files",
-                done="Project files generated",
-                spinner="arc",
-            ):
-                base_path.mkdir(parents=True, exist_ok=True)
-                created = self._copy_template_dir(
-                    template_dir, base_path, context, force=force, is_prod=is_prod
-                )
+            timeline = self.output.timeline(
+                f'Scaffolding "{context["agent_name"]}"',
+                steps=(
+                    ("workspace", "Preparing the project directory"),
+                    ("files", "Writing template files"),
+                    ("config", "Generating agentflow.json"),
+                ),
+            )
+            with timeline:
+                with timeline.step("workspace") as step:
+                    base_path.mkdir(parents=True, exist_ok=True)
+                    step.detail(str(base_path.resolve()))
 
-                # Regenerate agentflow.json from the built config. Force is safe only to
-                # override the copy this run just made; honor --force for a file that was
-                # already there.
-                config = self._build_config(context, is_prod)
-                self._write_file(
-                    config_path,
-                    json.dumps(config, indent=2) + "\n",
-                    force=force or not config_pre_existed,
-                )
-            if config_path not in created:
-                self._print_file_line(config_path, base_path)
+                with timeline.step("files") as step:
+                    created = self._copy_template_dir(
+                        template_dir,
+                        base_path,
+                        context,
+                        force=force,
+                        is_prod=is_prod,
+                        on_file=step.detail,
+                    )
+                    step.detail(f"{len(created)} files from the {template_dir.name} template")
+
+                with timeline.step("config") as step:
+                    # Regenerate agentflow.json from the built config. Force is safe only
+                    # to override the copy this run just made; honor --force for a file
+                    # that was already there.
+                    config = self._build_config(context, is_prod)
+                    self._write_file(
+                        config_path,
+                        json.dumps(config, indent=2) + "\n",
+                        force=force or not config_pre_existed,
+                    )
+                    step.detail(str(config_path))
 
             agent_name = context["agent_name"]
             self.output.completion_screen(
@@ -202,9 +216,7 @@ class InitCommand(BaseCommand):
         return {
             "agent_name": resolved_name,
             "agent_name_slug": slug,
-            "setup_type": "production"
-            if resolved_template == "production"
-            else "quick_start",
+            "setup_type": "production" if resolved_template == "production" else "quick_start",
             "auth": resolved_auth,
             "rate_limit": resolved_rate_limit,
             "rl_requests": 100,
@@ -348,10 +360,6 @@ class InitCommand(BaseCommand):
             title="Project summary",
         )
 
-    def _print_file_line(self, dest: Path, base_path: Path) -> None:
-        rel = dest.relative_to(base_path)
-        self.output.info(f"Created {rel}", emoji=False)
-
     def _print_next_steps(self, context: dict, is_prod: bool) -> None:
         steps: list[tuple[str, str]] = []
 
@@ -462,6 +470,7 @@ class InitCommand(BaseCommand):
         *,
         force: bool,
         is_prod: bool,
+        on_file: Callable[[str], None] | None = None,
     ) -> set[Path]:
         created: set[Path] = set()
         for src in sorted(template_dir.rglob("*")):
@@ -473,7 +482,8 @@ class InitCommand(BaseCommand):
             dest = dest_dir / rel
             content = self._render(src, context, is_prod)
             self._write_file(dest, content, force=force)
-            self._print_file_line(dest, dest_dir)
+            if on_file is not None:
+                on_file(str(rel).replace("\\", "/"))
             created.add(dest)
         return created
 

--- a/agentflow_cli/cli/commands/init.py
+++ b/agentflow_cli/cli/commands/init.py
@@ -61,8 +61,8 @@ class InitCommand(BaseCommand):
         **kwargs: Any,
     ) -> int:
         try:
-            self.output.print_banner(
-                "Init", "Create a new AgentFlow agent project", color="magenta"
+            self.output.command_header(
+                "init", "Create a new AgentFlow agent project", color="magenta"
             )
 
             context: dict[str, Any] | None
@@ -105,28 +105,43 @@ class InitCommand(BaseCommand):
                 self.output.info("Dry run complete; no files were written.", emoji=False)
                 return 0
 
-            base_path.mkdir(parents=True, exist_ok=True)
-            self.output.info("Creating project files...", emoji=False)
-            created = self._copy_template_dir(
-                template_dir, base_path, context, force=force, is_prod=is_prod
-            )
+            with self.output.activity(
+                "Scaffolding project files",
+                done="Project files generated",
+                spinner="arc",
+            ):
+                base_path.mkdir(parents=True, exist_ok=True)
+                created = self._copy_template_dir(
+                    template_dir, base_path, context, force=force, is_prod=is_prod
+                )
 
-            # Regenerate agentflow.json from the built config. Force is safe only to
-            # override the copy this run just made; honor --force for a file that was
-            # already there.
-            config = self._build_config(context, is_prod)
-            self._write_file(
-                config_path,
-                json.dumps(config, indent=2) + "\n",
-                force=force or not config_pre_existed,
-            )
+                # Regenerate agentflow.json from the built config. Force is safe only to
+                # override the copy this run just made; honor --force for a file that was
+                # already there.
+                config = self._build_config(context, is_prod)
+                self._write_file(
+                    config_path,
+                    json.dumps(config, indent=2) + "\n",
+                    force=force or not config_pre_existed,
+                )
             if config_path not in created:
                 self._print_file_line(config_path, base_path)
 
             agent_name = context["agent_name"]
-            self.output.success(f'Project "{agent_name}" ready at {base_path.resolve()}')
-
-            self._print_next_steps(context, is_prod)
+            self.output.completion_screen(
+                "Project ready",
+                f'"{agent_name}" was created successfully',
+                details={
+                    "Location": base_path.resolve(),
+                    "Template": "production" if is_prod else "quick-start",
+                    "Auth": context["auth"],
+                },
+                next_steps=[
+                    f"cd {base_path}",
+                    "Copy .env.example to .env and add your model API key.",
+                    "agentflow play",
+                ],
+            )
 
             return 0
 

--- a/agentflow_cli/cli/commands/init.py
+++ b/agentflow_cli/cli/commands/init.py
@@ -230,6 +230,13 @@ class InitCommand(BaseCommand):
 
     def _prompt_user(self) -> dict | None:  # noqa: PLR0911
         prompts = self.output.prompts()
+        prompts.require_interactive(
+            field="template",
+            alternatives=(
+                "Re-run with --yes to accept the defaults, or --non-interactive "
+                "with --name/--template for a reproducible recipe."
+            ),
+        )
 
         agent_name = prompts.text("What is your agent name?", default="MyAgent")
         if agent_name is None:

--- a/agentflow_cli/cli/commands/init.py
+++ b/agentflow_cli/cli/commands/init.py
@@ -8,9 +8,8 @@ from pathlib import Path
 from string import Template
 from typing import Any
 
-import questionary
-
 from agentflow_cli.cli.commands import BaseCommand
+from agentflow_cli.cli.core.prompts import Choice
 from agentflow_cli.cli.exceptions import FileOperationError, ValidationError
 
 
@@ -230,27 +229,36 @@ class InitCommand(BaseCommand):
     # ------------------------------------------------------------------
 
     def _prompt_user(self) -> dict | None:  # noqa: PLR0911
-        agent_name = questionary.text(
-            "What is your agent name?",
-            default="MyAgent",
-        ).ask()
+        prompts = self.output.prompts()
+
+        agent_name = prompts.text("What is your agent name?", default="MyAgent")
         if agent_name is None:
             return None
 
-        setup_choice = questionary.select(
-            "Quick Start or Production setup?",
-            choices=["Quick Start", "Production"],
-            default="Quick Start",
-        ).ask()
-        if setup_choice is None:
+        template = prompts.select(
+            "Which project template?",
+            [
+                Choice(
+                    "quick_start",
+                    "Quick Start",
+                    "Minimal graph, no auth — fastest path to a running agent",
+                ),
+                Choice(
+                    "production",
+                    "Production",
+                    "Auth, rate limiting, evals, and tests scaffolded in",
+                ),
+            ],
+            default="quick_start",
+        )
+        if template is None:
             return None
 
-        is_prod = setup_choice == "Production"
-
+        is_prod = template == "production"
         context: dict[str, Any] = {
             "agent_name": agent_name,
             "agent_name_slug": _slugify(agent_name),
-            "setup_type": "production" if is_prod else "quick_start",
+            "setup_type": template,
             "auth": "none",
             "rate_limit": "none",
         }
@@ -260,66 +268,75 @@ class InitCommand(BaseCommand):
 
         # --- Production questions ---
 
-        auth_choice = questionary.select(
-            "Authentication type?",
-            choices=["None", "JWT", "Custom"],
-            default="None",
-        ).ask()
-        if auth_choice is None:
+        auth = prompts.select(
+            "How should requests be authenticated?",
+            [
+                Choice("none", "None", "Open endpoints — development only"),
+                Choice("jwt", "JWT", "Requires JWT_SECRET_KEY and JWT_ALGORITHM"),
+                Choice("custom", "Custom", "Scaffolds a BaseAuth subclass under auth/"),
+            ],
+            default="none",
+        )
+        if auth is None:
             return None
-        context["auth"] = auth_choice.lower()
+        context["auth"] = auth
 
-        if context["auth"] == "none":
+        if auth == "none":
             return context
 
-        rl_choice = questionary.select(
-            "Rate limiting?",
-            choices=["None", "Memory Based", "Redis Based"],
-            default="None",
-        ).ask()
-        if rl_choice is None:
+        rate_limit = prompts.select(
+            "Rate limiting backend?",
+            [
+                Choice("none", "None", "No request throttling"),
+                Choice("memory", "Memory", "Per-process counters — single instance only"),
+                Choice("redis", "Redis", "Shared counters — requires REDIS_URL"),
+            ],
+            default="none",
+        )
+        if rate_limit is None:
             return None
-        context["rate_limit"] = {
-            "None": "none",
-            "Memory Based": "memory",
-            "Redis Based": "redis",
-        }[rl_choice]
+        context["rate_limit"] = rate_limit
 
-        if context["rate_limit"] != "none":
-            rl_requests = questionary.text(
-                "Max requests per window?",
-                default="100",
-                validate=lambda v: (v.isdigit() and int(v) > 0) or "Enter a positive integer",
-            ).ask()
-            if rl_requests is None:
-                return None
-            context["rl_requests"] = int(rl_requests)
+        if rate_limit == "none":
+            return context
 
-            rl_window = questionary.text(
-                "Window size (seconds)?",
-                default="60",
-                validate=lambda v: (v.isdigit() and int(v) > 0) or "Enter a positive integer",
-            ).ask()
-            if rl_window is None:
-                return None
-            context["rl_window"] = int(rl_window)
+        rl_requests = prompts.text(
+            "Max requests per window?",
+            default="100",
+            validate=lambda v: (v.isdigit() and int(v) > 0) or "Enter a positive integer",
+        )
+        if rl_requests is None:
+            return None
+        context["rl_requests"] = int(rl_requests)
 
-            rl_by = questionary.select(
-                "Limit by?",
-                choices=["Per IP (recommended)", "Global"],
-                default="Per IP (recommended)",
-            ).ask()
-            if rl_by is None:
-                return None
-            context["rl_by"] = "ip" if "IP" in rl_by else "global"
+        rl_window = prompts.text(
+            "Window size (seconds)?",
+            default="60",
+            validate=lambda v: (v.isdigit() and int(v) > 0) or "Enter a positive integer",
+        )
+        if rl_window is None:
+            return None
+        context["rl_window"] = int(rl_window)
 
-            rl_proxy = questionary.confirm(
-                "Behind a reverse proxy? (reads real IP from forwarded headers)",
-                default=False,
-            ).ask()
-            if rl_proxy is None:
-                return None
-            context["rl_trusted_proxy"] = rl_proxy
+        rl_by = prompts.select(
+            "Count requests per?",
+            [
+                Choice("ip", "Per IP", "Recommended — each client gets its own budget"),
+                Choice("global", "Global", "One shared budget across all clients"),
+            ],
+            default="ip",
+        )
+        if rl_by is None:
+            return None
+        context["rl_by"] = rl_by
+
+        rl_proxy = prompts.confirm(
+            "Behind a reverse proxy? (reads the real IP from forwarded headers)",
+            default=False,
+        )
+        if rl_proxy is None:
+            return None
+        context["rl_trusted_proxy"] = rl_proxy
 
         return context
 

--- a/agentflow_cli/cli/commands/init.py
+++ b/agentflow_cli/cli/commands/init.py
@@ -8,27 +8,16 @@ from string import Template
 from typing import Any
 
 import questionary
-import typer
 
 from agentflow_cli.cli.commands import BaseCommand
-from agentflow_cli.cli.constants import Colors
-from agentflow_cli.cli.exceptions import FileOperationError
+from agentflow_cli.cli.exceptions import FileOperationError, ValidationError
 
 
 _TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
 _SKIP_DIRS = {"__pycache__", ".ruff_cache"}
-_DIVIDER = Colors.colorize("  " + "─" * 46, "cyan")
 
 # Directories inside prod/ that are only included based on user choices
 _AUTH_DIR = "auth"
-
-
-def _dim(text: str) -> str:
-    return f"\033[2m{text}\033[0m"
-
-
-def _bold(text: str) -> str:
-    return f"\033[1m{text}\033[0m"
 
 
 def _slugify(name: str) -> str:
@@ -58,15 +47,37 @@ def _strip_env_blocks(content: str, *, keep_redis: bool, keep_jwt: bool) -> str:
 class InitCommand(BaseCommand):
     """Command to initialize a new agent project interactively."""
 
-    def execute(self, path: str = ".", force: bool = False, **kwargs: Any) -> int:
+    def execute(
+        self,
+        path: str = ".",
+        force: bool = False,
+        agent_name: str | None = None,
+        template: str | None = None,
+        auth: str | None = None,
+        rate_limit: str | None = None,
+        yes: bool = False,
+        non_interactive: bool = False,
+        dry_run: bool = False,
+        **kwargs: Any,
+    ) -> int:
         try:
             self.output.print_banner(
                 "Init", "Create a new AgentFlow agent project", color="magenta"
             )
 
-            context = self._prompt_user()
+            context: dict[str, Any] | None
+            if yes or non_interactive:
+                context = self._non_interactive_context(
+                    path=path,
+                    agent_name=agent_name,
+                    template=template,
+                    auth=auth,
+                    rate_limit=rate_limit,
+                )
+            else:
+                context = self._prompt_user()
             if context is None:
-                typer.echo("\n  Cancelled.")
+                self.output.info("Cancelled.", emoji=False)
                 return 0
 
             self._print_summary(context)
@@ -77,12 +88,25 @@ class InitCommand(BaseCommand):
             # clobbered unless they passed --force.
             config_path = base_path / "agentflow.json"
             config_pre_existed = config_path.exists()
-            base_path.mkdir(parents=True, exist_ok=True)
 
             is_prod = context["setup_type"] == "production"
             template_dir = _TEMPLATES_DIR / ("prod" if is_prod else "dev")
 
-            typer.echo(f"\n  {_bold('Creating project files...')}\n")
+            if dry_run:
+                planned = [
+                    str(src.relative_to(template_dir))
+                    for src in sorted(template_dir.rglob("*"))
+                    if src.is_file()
+                    and not self._should_skip(src, template_dir, context, is_prod)
+                ]
+                if "agentflow.json" not in planned:
+                    planned.append("agentflow.json")
+                self.output.print_list(planned, title="Files that would be created", bullet="→")
+                self.output.info("Dry run complete; no files were written.", emoji=False)
+                return 0
+
+            base_path.mkdir(parents=True, exist_ok=True)
+            self.output.info("Creating project files...", emoji=False)
             created = self._copy_template_dir(
                 template_dir, base_path, context, force=force, is_prod=is_prod
             )
@@ -100,23 +124,79 @@ class InitCommand(BaseCommand):
                 self._print_file_line(config_path, base_path)
 
             agent_name = context["agent_name"]
-            typer.echo("")
-            typer.echo(_DIVIDER)
-            typer.echo(
-                "  ✨  "
-                + Colors.colorize(f'Project "{agent_name}" ready at ', "green")
-                + Colors.colorize(str(base_path.resolve()), "cyan")
-            )
-            typer.echo(_DIVIDER)
+            self.output.success(f'Project "{agent_name}" ready at {base_path.resolve()}')
 
             self._print_next_steps(context, is_prod)
 
             return 0
 
-        except FileOperationError as e:
+        except (FileOperationError, ValidationError) as e:
             return self.handle_error(e)
         except Exception as e:
             return self.handle_error(FileOperationError(f"Failed to initialize project: {e}"))
+
+    def _non_interactive_context(
+        self,
+        *,
+        path: str,
+        agent_name: str | None,
+        template: str | None,
+        auth: str | None,
+        rate_limit: str | None,
+    ) -> dict[str, Any]:
+        """Resolve a complete, reproducible scaffold recipe without prompting."""
+        resolved_template = (template or "quick-start").strip().lower().replace("_", "-")
+        if resolved_template not in {"quick-start", "production"}:
+            raise ValidationError(
+                f"Invalid template '{resolved_template}'. Choose quick-start or production.",
+                field="template",
+            )
+
+        inferred_name = Path(path).resolve().name if path not in {"", "."} else "MyAgent"
+        resolved_name = (agent_name or inferred_name).strip()
+        slug = _slugify(resolved_name)
+        if not resolved_name or not slug:
+            raise ValidationError(
+                "Agent name must contain at least one letter or number.",
+                field="name",
+            )
+
+        resolved_auth = (auth or "none").strip().lower()
+        if resolved_auth not in {"none", "jwt", "custom"}:
+            raise ValidationError(
+                f"Invalid auth mode '{resolved_auth}'. Choose none, jwt, or custom.",
+                field="auth",
+            )
+
+        resolved_rate_limit = (rate_limit or "none").strip().lower()
+        if resolved_rate_limit not in {"none", "memory", "redis"}:
+            raise ValidationError(
+                f"Invalid rate-limit mode '{resolved_rate_limit}'. "
+                "Choose none, memory, or redis.",
+                field="rate_limit",
+            )
+
+        if resolved_template == "quick-start" and (
+            resolved_auth != "none" or resolved_rate_limit != "none"
+        ):
+            raise ValidationError(
+                "--auth and --rate-limit require --template production.",
+                field="template",
+            )
+
+        return {
+            "agent_name": resolved_name,
+            "agent_name_slug": slug,
+            "setup_type": "production"
+            if resolved_template == "production"
+            else "quick_start",
+            "auth": resolved_auth,
+            "rate_limit": resolved_rate_limit,
+            "rl_requests": 100,
+            "rl_window": 60,
+            "rl_by": "ip",
+            "rl_trusted_proxy": False,
+        }
 
     # ------------------------------------------------------------------
     # Prompts
@@ -224,11 +304,6 @@ class InitCommand(BaseCommand):
         is_prod = context["setup_type"] == "production"
         setup_label = "Production" if is_prod else "Quick Start"
 
-        typer.echo("")
-        typer.echo(_DIVIDER)
-        typer.echo("  " + _bold("Project Summary"))
-        typer.echo(_DIVIDER)
-
         rows: list[tuple[str, str]] = [
             ("Agent name", context["agent_name"]),
             ("Package name", context["agent_name_slug"]),
@@ -252,19 +327,15 @@ class InitCommand(BaseCommand):
                     )
                 )
 
-        label_width = max(len(k) for k, _ in rows) + 2
-        for label, value in rows:
-            padded = (label + " ").ljust(label_width, "·")
-            typer.echo(
-                "  " + Colors.colorize(padded, "cyan") + "  " + Colors.colorize(value, "white")
-            )
-        typer.echo(_DIVIDER)
+        self.output.print_table(
+            ["Setting", "Value"],
+            [[label, value] for label, value in rows],
+            title="Project summary",
+        )
 
     def _print_file_line(self, dest: Path, base_path: Path) -> None:
         rel = dest.relative_to(base_path)
-        typer.echo(
-            "    " + Colors.colorize("✓", "green") + "  " + Colors.colorize(str(rel), "white")
-        )
+        self.output.info(f"Created {rel}", emoji=False)
 
     def _print_next_steps(self, context: dict, is_prod: bool) -> None:
         steps: list[tuple[str, str]] = []
@@ -285,18 +356,14 @@ class InitCommand(BaseCommand):
 
         steps.append(("agentflow play", "Launch your agent"))
 
-        typer.echo("")
-        typer.echo("  " + Colors.colorize("🚀  Next steps", "magenta"))
-        typer.echo("")
-
-        cmd_width = max(len(cmd) for cmd, _ in steps) + 2
-        for i, (cmd, description) in enumerate(steps, 1):
-            num = Colors.colorize(f"  {i}", "cyan")
-            command = Colors.colorize(cmd.ljust(cmd_width), "yellow")
-            desc = _dim(description)
-            typer.echo(f"{num}  {command}  {desc}")
-
-        typer.echo("")
+        self.output.print_table(
+            ["#", "Command", "Purpose"],
+            [
+                [str(index), command, description]
+                for index, (command, description) in enumerate(steps, 1)
+            ],
+            title="Next steps",
+        )
 
     # ------------------------------------------------------------------
     # Config generation

--- a/agentflow_cli/cli/commands/skills.py
+++ b/agentflow_cli/cli/commands/skills.py
@@ -4,16 +4,14 @@ from __future__ import annotations
 
 import json
 import shutil
-import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
-import typer
-
 from agentflow_cli.cli.commands import BaseCommand
 from agentflow_cli.cli.constants import CLI_VERSION
+from agentflow_cli.cli.core.prompts import Choice
 from agentflow_cli.cli.exceptions import FileOperationError, ValidationError
 
 
@@ -152,11 +150,27 @@ class SkillsCommand(BaseCommand):
             project_root = self._safe_project_root(path)
 
             if all_agents:
-                return self._install_all(templates_root, project_root, force=force)
+                targets: tuple[_AgentTarget, ...] = _TARGETS
+            elif agent:
+                targets = (self._normalize_agent(agent),)
+            else:
+                selected = self._choose_agents(project_root)
+                if selected is None:
+                    self.output.info("Cancelled.", emoji=False)
+                    return 0
+                targets = selected
 
-            target = self._select_agent(agent)
-            self._install_one(templates_root, project_root, target, force=force)
-            return 0
+            force = force or self._confirm_overwrite(project_root, targets, force=force)
+            return self._install_targets(
+                templates_root,
+                project_root,
+                targets,
+                force=force,
+                # Naming one agent is a request for that agent specifically, so a
+                # collision is an error. A set the user did not enumerate — --all,
+                # or a multi-select — skips what is already there instead.
+                strict=bool(agent),
+            )
 
         except (FileOperationError, ValidationError) as e:
             return self.handle_error(e)
@@ -165,6 +179,152 @@ class SkillsCommand(BaseCommand):
             file_error.__cause__ = e
             return self.handle_error(file_error)
 
+    # ------------------------------------------------------------------
+    # Selection
+    # ------------------------------------------------------------------
+
+    def _choose_agents(self, project_root: Path) -> tuple[_AgentTarget, ...] | None:
+        """Offer a space-to-toggle list of agents. Returns None if cancelled."""
+        prompts = self.output.prompts()
+        prompts.require_interactive(
+            field="agent",
+            alternatives="Pass --agent codex|claude|github, or --all.",
+        )
+
+        choices = [
+            Choice(
+                value=target.name,
+                title=target.name,
+                description=self._choice_description(project_root, target),
+                # Pre-check what is already installed, so confirming without
+                # touching anything reinstalls exactly what is already there.
+                checked=bool(self._existing_paths(project_root, target)),
+            )
+            for target in _TARGETS
+        ]
+        names = prompts.checkbox(
+            "Which agents should get the Agentflow skill?",
+            choices,
+            validate=lambda selected: bool(selected) or "Select at least one agent.",
+        )
+        if names is None:
+            return None
+        return tuple(_AGENT_LOOKUP[name.lower()] for name in names)
+
+    def _choice_description(self, project_root: Path, target: _AgentTarget) -> str:
+        install_root = target.artifacts[0].install_relpath
+        if self._existing_paths(project_root, target):
+            return f"{install_root}  (installed)"
+        return install_root
+
+    @staticmethod
+    def _existing_paths(project_root: Path, target: _AgentTarget) -> list[Path]:
+        return [
+            project_root / artifact.install_relpath
+            for artifact in target.artifacts
+            if (project_root / artifact.install_relpath).exists()
+        ]
+
+    def _confirm_overwrite(
+        self,
+        project_root: Path,
+        targets: tuple[_AgentTarget, ...],
+        *,
+        force: bool,
+    ) -> bool:
+        """Offer to overwrite in place of failing, when a human is present."""
+        if force:
+            return False
+        occupied = [t.name for t in targets if self._existing_paths(project_root, t)]
+        if not occupied:
+            return False
+
+        prompts = self.output.prompts()
+        if not prompts.interactive:
+            # Non-interactive callers keep the previous contract: refuse and
+            # point at --force rather than silently replacing files.
+            return False
+        return bool(
+            prompts.confirm(
+                f"Overwrite the existing install for {', '.join(occupied)}?",
+                default=True,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Installation
+    # ------------------------------------------------------------------
+
+    def _install_targets(
+        self,
+        templates_root: Path,
+        project_root: Path,
+        targets: tuple[_AgentTarget, ...],
+        *,
+        force: bool,
+        strict: bool,
+    ) -> int:
+        installed: list[str] = []
+        skipped: list[str] = []
+        failed: list[str] = []
+
+        timeline = self.output.timeline(
+            "Installing Agentflow skills",
+            steps=tuple((target.name.lower(), f"{target.name} skill") for target in targets),
+        )
+        with timeline:
+            for target in targets:
+                with timeline.step(target.name.lower()) as step:
+                    existing = self._existing_paths(project_root, target)
+                    if existing and not force:
+                        if strict:
+                            paths = ", ".join(str(dest) for dest in existing)
+                            raise FileOperationError(
+                                f"Skill already installed at {paths}. " "Use --force to overwrite.",
+                                file_path=str(existing[0]),
+                            )
+                        step.skip("already installed — pass --force to overwrite")
+                        skipped.append(target.name)
+                        continue
+                    try:
+                        paths = self._install_one(templates_root, project_root, target, force=force)
+                    except (FileOperationError, OSError, UnicodeError) as exc:
+                        # Record and continue: one unwritable target should not
+                        # cancel the agents the user also asked for.
+                        self.logger.error("Install failed for %s: %s", target.name, exc)
+                        failed.append(f"{target.name}: {exc}")
+                        step.fail(str(exc))
+                        continue
+                    installed.append(target.name)
+                    step.detail(paths[0])
+
+        for target in targets:
+            if target.name in installed:
+                self._print_activation_hint(target)
+
+        if skipped:
+            self.output.warning(
+                "Skipped existing installs (use --force to overwrite): " + ", ".join(skipped)
+            )
+        if failed:
+            self.output.error("Failed installs: " + "; ".join(failed))
+            if not installed:
+                return 1
+
+        self.output.completion_screen(
+            "Skills installed" if installed else "Nothing to install",
+            f"{len(installed)} agent(s) ready" if installed else "Every selection was skipped",
+            details={
+                "Installed": ", ".join(installed) or "none",
+                "Skipped": ", ".join(skipped) or "none",
+                "Project": project_root,
+            },
+            next_steps=["Restart your coding agent so it loads the new skill directory."]
+            if installed
+            else [],
+        )
+        return 0
+
     def _install_one(
         self,
         templates_root: Path,
@@ -172,7 +332,7 @@ class SkillsCommand(BaseCommand):
         target: _AgentTarget,
         *,
         force: bool,
-    ) -> None:
+    ) -> list[str]:
         installs = [
             (
                 artifact,
@@ -218,10 +378,7 @@ class SkillsCommand(BaseCommand):
                 shutil.copyfile(source, dest)
             installed_paths.append(str(dest))
 
-        self.output.success(
-            f"Installed Agentflow skills for {target.name} at {', '.join(installed_paths)}"
-        )
-        self._print_activation_hint(target)
+        return installed_paths
 
     def _print_activation_hint(self, target: _AgentTarget) -> None:
         """Tell the user how to make the freshly installed skill take effect.
@@ -249,38 +406,6 @@ class SkillsCommand(BaseCommand):
                 ".github/skills/ directory and .github/instructions/ file."
             )
         self.output.warning(f"Activate: {note}")
-
-    def _install_all(self, templates_root: Path, project_root: Path, *, force: bool) -> int:
-        installed = 0
-        skipped: list[str] = []
-        failed: list[str] = []
-        for target in _TARGETS:
-            existing = [
-                project_root / artifact.install_relpath
-                for artifact in target.artifacts
-                if (project_root / artifact.install_relpath).exists()
-            ]
-            if existing and not force:
-                paths = ", ".join(str(dest) for dest in existing)
-                skipped.append(f"{target.name} ({paths})")
-                continue
-            try:
-                self._install_one(templates_root, project_root, target, force=force)
-                installed += 1
-            except (FileOperationError, OSError, UnicodeError) as e:
-                self.logger.error("Install failed for %s: %s", target.name, e)
-                failed.append(f"{target.name}: {e}")
-
-        if skipped:
-            self.output.warning(
-                "Skipped existing installs (use --force to overwrite): " + ", ".join(skipped)
-            )
-        if failed:
-            self.output.error("Failed installs: " + "; ".join(failed))
-
-        if failed and installed == 0:
-            return 1
-        return 0
 
     def _write_manifest(self, target_dir: Path, agent_name: str) -> None:
         manifest = {
@@ -316,25 +441,6 @@ class SkillsCommand(BaseCommand):
                 field="path",
             )
         return project_root
-
-    def _select_agent(self, agent: str | None) -> _AgentTarget:
-        if agent:
-            return self._normalize_agent(agent)
-
-        if not sys.stdin.isatty():
-            raise ValidationError(
-                "No --agent provided and stdin is not interactive. "
-                "Pass --agent codex|claude|github or --all.",
-                field="agent",
-            )
-
-        self.output.print_list(
-            [f"{i}. {t.name}" for i, t in enumerate(_TARGETS, 1)],
-            title="Which agent?",
-            bullet="-",
-        )
-        selected = typer.prompt("Select an agent", default="1")
-        return self._normalize_agent(selected)
 
     def _normalize_agent(self, value: str) -> _AgentTarget:
         key = value.strip().lower()

--- a/agentflow_cli/cli/commands/skills.py
+++ b/agentflow_cli/cli/commands/skills.py
@@ -287,7 +287,9 @@ class SkillsCommand(BaseCommand):
                         skipped.append(target.name)
                         continue
                     try:
-                        paths = self._install_one(templates_root, project_root, target, force=force)
+                        written = self._install_one(
+                            templates_root, project_root, target, force=force
+                        )
                     except (FileOperationError, OSError, UnicodeError) as exc:
                         # Record and continue: one unwritable target should not
                         # cancel the agents the user also asked for.
@@ -296,7 +298,7 @@ class SkillsCommand(BaseCommand):
                         step.fail(str(exc))
                         continue
                     installed.append(target.name)
-                    step.detail(paths[0])
+                    step.detail(written[0])
 
         for target in targets:
             if target.name in installed:

--- a/agentflow_cli/cli/commands/skills.py
+++ b/agentflow_cli/cli/commands/skills.py
@@ -135,8 +135,8 @@ class SkillsCommand(BaseCommand):
             Exit code.
         """
         try:
-            self.output.print_banner(
-                "Skills",
+            self.output.command_header(
+                "skills",
                 "Install bundled Agentflow skills for Codex, Claude, or GitHub Copilot.",
                 color="magenta",
             )

--- a/agentflow_cli/cli/commands/test.py
+++ b/agentflow_cli/cli/commands/test.py
@@ -43,7 +43,7 @@ class TestCommand(BaseCommand):
         coverage_threshold: int | None = cfg.get("coverage_threshold")
 
         location = str(project_root / resolved_path) if resolved_path else str(project_root)
-        self.output.print_banner("Test", f"Running tests in {location}")
+        self.output.command_header("test", f"Running tests in {location}")
 
         cmd = [sys.executable, "-m", "pytest"]
         if resolved_path:
@@ -75,7 +75,19 @@ class TestCommand(BaseCommand):
         result = subprocess.run(cmd, cwd=project_root, check=False)  # nosec: B603  # noqa: S603
 
         if result.returncode == 0:
-            self.output.success("All tests passed.")
+            self.output.completion_screen(
+                "Tests passed",
+                "The project test suite completed successfully",
+                details={
+                    "Location": location,
+                    "Coverage": "enabled" if resolved_coverage else "disabled",
+                },
+                next_steps=(
+                    ["Open htmlcov/index.html to inspect the coverage report."]
+                    if resolved_coverage
+                    else []
+                ),
+            )
         else:
             self.output.error(f"Tests finished with exit code {result.returncode}.")
 

--- a/agentflow_cli/cli/commands/test.py
+++ b/agentflow_cli/cli/commands/test.py
@@ -25,53 +25,67 @@ class TestCommand(BaseCommand):
         **kwargs: Any,
     ) -> int:
         project_root = Path.cwd()
+        self.output.command_header("test", f"Running the project test suite in {project_root}")
 
-        # Load optional overrides from agentflow.json
-        cfg: dict[str, Any] = {}
-        config_manager = ConfigManager()
-        discovered = config_manager.auto_discover_config()
-        if discovered:
-            try:
-                config_manager.load_config(str(discovered))
-                cfg = config_manager.get_test_config()
-            except Exception:  # nosec: B110
-                self.logger.warning("Failed to load test configuration from %s", discovered)
+        timeline = self.output.timeline(
+            "Preparing the test run",
+            steps=(
+                ("config", "Resolving test configuration"),
+                ("command", "Building the pytest command"),
+            ),
+        )
+        with timeline:
+            with timeline.step("config") as step:
+                # Load optional overrides from agentflow.json
+                cfg: dict[str, Any] = {}
+                config_manager = ConfigManager()
+                discovered = config_manager.auto_discover_config()
+                if discovered:
+                    try:
+                        config_manager.load_config(str(discovered))
+                        cfg = config_manager.get_test_config()
+                        step.detail(str(discovered))
+                    except Exception:  # nosec: B110
+                        self.logger.warning("Failed to load test configuration from %s", discovered)
+                        step.detail(f"ignored unreadable config at {discovered}")
+                else:
+                    step.detail("no agentflow.json found — using pytest defaults")
 
-        # Explicit CLI path wins; fall back to agentflow.json; None = pytest auto-discovery
-        resolved_path: str | None = path or cfg.get("path") or None
-        resolved_coverage = coverage or cfg.get("coverage", False)
-        coverage_threshold: int | None = cfg.get("coverage_threshold")
+                # Explicit CLI path wins; agentflow.json next; None = pytest auto-discovery
+                resolved_path: str | None = path or cfg.get("path") or None
+                resolved_coverage = coverage or cfg.get("coverage", False)
+                coverage_threshold: int | None = cfg.get("coverage_threshold")
+                location = str(project_root / resolved_path) if resolved_path else str(project_root)
 
-        location = str(project_root / resolved_path) if resolved_path else str(project_root)
-        self.output.command_header("test", f"Running tests in {location}")
+            with timeline.step("command") as step:
+                cmd = [sys.executable, "-m", "pytest"]
+                if resolved_path:
+                    cmd.append(resolved_path)
 
-        cmd = [sys.executable, "-m", "pytest"]
-        if resolved_path:
-            cmd.append(resolved_path)
+                if quiet and not verbose:
+                    cmd.append("-q")
+                else:
+                    cmd.append("-v")
 
-        if verbose:
-            cmd.append("-v")
-        elif quiet:
-            cmd.append("-q")
-        else:
-            cmd.append("-v")
+                if resolved_coverage:
+                    cmd += [
+                        "--cov=.",
+                        "--cov-report=term-missing",
+                        "--cov-report=html:htmlcov",
+                    ]
+                    if coverage_threshold is not None:
+                        cmd.append(f"--cov-fail-under={coverage_threshold}")
 
-        if resolved_coverage:
-            cmd += [
-                "--cov=.",
-                "--cov-report=term-missing",
-                "--cov-report=html:htmlcov",
-            ]
-            if coverage_threshold is not None:
-                cmd.append(f"--cov-fail-under={coverage_threshold}")
+                if keyword:
+                    cmd += ["-k", keyword]
 
-        if keyword:
-            cmd += ["-k", keyword]
-
-        cmd += list(extra_args)
+                cmd += list(extra_args)
+                step.detail(" ".join(["pytest", *cmd[3:]]))
 
         self.logger.info("Running: %s", " ".join(cmd))
 
+        # No spinner around this: pytest owns the terminal while it streams its
+        # own progress, and a live region would fight it for the cursor.
         result = subprocess.run(cmd, cwd=project_root, check=False)  # nosec: B603  # noqa: S603
 
         if result.returncode == 0:

--- a/agentflow_cli/cli/commands/version.py
+++ b/agentflow_cli/cli/commands/version.py
@@ -18,9 +18,8 @@ class VersionCommand(BaseCommand):
             Exit code
         """
         try:
-            # Print banner
-            self.output.print_banner(
-                "Version",
+            self.output.command_header(
+                "version",
                 "Show Agentflow CLI and package version info",
                 color="green",
             )

--- a/agentflow_cli/cli/context.py
+++ b/agentflow_cli/cli/context.py
@@ -1,0 +1,46 @@
+"""Shared runtime context for Agentflow CLI commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import uuid4
+
+from agentflow_cli.cli.capabilities import TerminalCapabilities
+
+
+@dataclass(frozen=True)
+class CLIContext:
+    """Invocation-scoped CLI state passed through Typer's context object."""
+
+    capabilities: TerminalCapabilities
+    cwd: Path
+    verbosity: int = 0
+    quiet: bool = False
+    debug: bool = False
+    yes: bool = False
+    non_interactive: bool = False
+    invocation_id: str = ""
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        capabilities: TerminalCapabilities,
+        cwd: Path,
+        verbosity: int = 0,
+        quiet: bool = False,
+        debug: bool = False,
+        yes: bool = False,
+        non_interactive: bool = False,
+    ) -> CLIContext:
+        return cls(
+            capabilities=capabilities,
+            cwd=cwd,
+            verbosity=verbosity,
+            quiet=quiet,
+            debug=debug,
+            yes=yes,
+            non_interactive=non_interactive,
+            invocation_id=uuid4().hex[:12],
+        )

--- a/agentflow_cli/cli/core/animations.py
+++ b/agentflow_cli/cli/core/animations.py
@@ -1,11 +1,12 @@
 """Terminal-native animation engine for the Agentflow CLI.
 
-The intro deliberately runs on the *alternate* screen and then hands the
-terminal back. An alternate screen is discarded by the terminal when it is
-released, so anything a command prints while holding one is lost the moment the
-process exits. Motion therefore gets the full canvas for as long as it is
-running, and every durable line — headers, timelines, results — is written to
-the normal buffer where it stays in scrollback.
+The intro always plays on the full canvas; what differs is who owns that canvas.
+Inside an :class:`~agentflow_cli.cli.core.screen.AppFrame` the frame already
+holds the alternate screen and keeps it, so the sequence renders in place and
+collapses into the frame's pinned chrome. Without a frame the intro claims a
+temporary screen of its own and hands the terminal back, then prints a durable
+header — because a released alternate screen is discarded, and everything the
+command goes on to print has to survive in the normal buffer.
 
 Frames are generated from a normalized ``0.0 -> 1.0`` timeline rather than a
 fixed frame list so the same choreography adapts to terminal width, refresh
@@ -16,6 +17,7 @@ from __future__ import annotations
 
 import math
 import time
+from contextlib import nullcontext
 
 from rich.align import Align
 from rich.console import Console, Group, RenderableType
@@ -23,6 +25,7 @@ from rich.live import Live
 from rich.text import Text
 
 from agentflow_cli.cli.constants import CLI_VERSION
+from agentflow_cli.cli.core.screen import BACKGROUND
 from agentflow_cli.cli.core.theme import (
     BRAND_RAMP,
     Glyphs,
@@ -171,14 +174,15 @@ def _play_cinematic(
     command: str,
     subtitle: str | None,
     glyphs: Glyphs,
+    own_screen: bool = True,
 ) -> None:
-    """Run the full-canvas reveal on a temporary alternate screen."""
+    """Run the full-canvas reveal, optionally claiming a screen of its own."""
     frame_interval = 1.0 / INTRO_FPS
     frame_count = max(int(INTRO_DURATION_SECONDS * INTRO_FPS), 1)
     tagline = _TAGLINES.get(command.lower(), subtitle or _DEFAULT_TAGLINE)
 
     with (
-        console.screen(style="on #0b0b12", hide_cursor=True),
+        console.screen(style=f"on {BACKGROUND}", hide_cursor=True) if own_screen else nullcontext(),
         Live(
             console=console,
             auto_refresh=False,
@@ -269,7 +273,7 @@ def _cinematic_frame(
         Group(*layers),
         vertical="middle",
         height=max(console.height - 1, 12),
-        style="on #0b0b12",
+        style=f"on {BACKGROUND}",
     )
 
 

--- a/agentflow_cli/cli/core/animations.py
+++ b/agentflow_cli/cli/core/animations.py
@@ -1,113 +1,89 @@
-"""Terminal-native animation assets and renderers.
+"""Terminal-native animation engine for the Agentflow CLI.
 
-Frames stay independent from colors so terminal themes and accessibility
-preferences can decide how semantic roles are rendered at runtime.
+The intro deliberately runs on the *alternate* screen and then hands the
+terminal back. An alternate screen is discarded by the terminal when it is
+released, so anything a command prints while holding one is lost the moment the
+process exits. Motion therefore gets the full canvas for as long as it is
+running, and every durable line — headers, timelines, results — is written to
+the normal buffer where it stays in scrollback.
+
+Frames are generated from a normalized ``0.0 -> 1.0`` timeline rather than a
+fixed frame list so the same choreography adapts to terminal width, refresh
+rate, and the reduced-motion budget without being re-authored.
 """
 
 from __future__ import annotations
 
+import math
 import time
-from dataclasses import dataclass
 
 from rich.align import Align
 from rich.console import Console, Group, RenderableType
 from rich.live import Live
 from rich.text import Text
 
-
-@dataclass(frozen=True)
-class AnimationFrame:
-    """One terminal animation frame with its display duration."""
-
-    lines: tuple[str, ...]
-    duration: float = 0.07
-
-
-_BRAND_UNICODE_FRAMES = (
-    AnimationFrame(("                    ", "         ·          ", "                    ")),
-    AnimationFrame(("                    ", "       ·─◆─·        ", "                    ")),
-    AnimationFrame(("       ╭───╮        ", "       │ ◆ │        ", "       ╰───╯        ")),
-    AnimationFrame(("   ◆───╭───╮───◆    ", "       │ A │        ", "   ◆───╰───╯───◆    ")),
-    AnimationFrame(("   ◆───╭───╮───◆    ", "       │ AF│  AGENT ", "   ◆───╰───╯───◆    ")),
-    AnimationFrame(
-        ("   ◆───╭───╮───◆    ", "       │ AF│  AGENTFLOW", "   ◆───╰───╯───◆    "),
-        0.12,
-    ),
+from agentflow_cli.cli.constants import CLI_VERSION
+from agentflow_cli.cli.core.theme import (
+    BRAND_RAMP,
+    Glyphs,
+    dim_hex,
+    glyphs_for,
+    gradient_rule,
+    gradient_text,
+    sample_ramp,
 )
 
-_BRAND_ASCII_FRAMES = (
-    AnimationFrame(("                    ", "         .          ", "                    ")),
-    AnimationFrame(("                    ", "       .-O-.        ", "                    ")),
-    AnimationFrame(("       +---+        ", "       | O |        ", "       +---+        ")),
-    AnimationFrame(("   O---+---+---O    ", "       | A |        ", "   O---+---+---O    ")),
-    AnimationFrame(("   O---+---+---O    ", "       | AF|  AGENT ", "   O---+---+---O    ")),
-    AnimationFrame(
-        ("   O---+---+---O    ", "       | AF|  AGENTFLOW", "   O---+---+---O    "),
-        0.12,
-    ),
-)
 
-_NETWORK_UNICODE_FRAMES = (
-    AnimationFrame(("        ◌          ", "        │          ", "    ◌───◆───◌      ")),
-    AnimationFrame(("        ◉          ", "        ┃          ", "    ◌───◆───◌      ")),
-    AnimationFrame(("        ◌          ", "        │          ", "    ◉━━━◆━━━◉      ")),
-    AnimationFrame(("    ◌───◆───◌      ", "        ┃          ", "    ◉━━━◆━━━◉      ")),
-    AnimationFrame(("    ◉━━━◆━━━◉      ", "        ┃          ", "    ◉━━━◆━━━◉      "), 0.12),
-)
+INTRO_DURATION_SECONDS = 1.25
+INTRO_FPS = 30
+_MIN_CINEMATIC_HEIGHT = 16
+# Column distance over which the reveal front and the shimmer stay lit.
+_REVEAL_FRONT_WIDTH = 1.6
+_SHIMMER_WIDTH = 2.5
+_MIN_CINEMATIC_WIDTH = 62
 
-_NETWORK_ASCII_FRAMES = (
-    AnimationFrame(("        o          ", "        |          ", "    o---O---o      ")),
-    AnimationFrame(("        O          ", "        |          ", "    o---O---o      ")),
-    AnimationFrame(("        o          ", "        |          ", "    O===O===O      ")),
-    AnimationFrame(("    o---O---o      ", "        |          ", "    O===O===O      ")),
-    AnimationFrame(("    O===O===O      ", "        |          ", "    O===O===O      "), 0.12),
-)
+# 5x5 block glyphs. Only the letters in "AGENTFLOW" are needed; anything else
+# falls back to the compact wordmark.
+_BLOCK_FONT: dict[str, tuple[str, ...]] = {
+    "A": (" ███ ", "█   █", "█████", "█   █", "█   █"),
+    "G": (" ████", "█    ", "█  ██", "█   █", " ████"),
+    "E": ("█████", "█    ", "████ ", "█    ", "█████"),
+    "N": ("█   █", "██  █", "█ █ █", "█  ██", "█   █"),
+    "T": ("█████", "  █  ", "  █  ", "  █  ", "  █  "),
+    "F": ("█████", "█    ", "████ ", "█    ", "█    "),
+    "L": ("█    ", "█    ", "█    ", "█    ", "█████"),
+    "O": (" ███ ", "█   █", "█   █", "█   █", " ███ "),
+    "W": ("█   █", "█   █", "█ █ █", "██ ██", "█   █"),
+}
+_WORDMARK = "AGENTFLOW"
+_BLOCK_ROWS = 5
 
-_SCAFFOLD_UNICODE_FRAMES = (
-    AnimationFrame(("    ╭           ╮  ", "                   ", "    ╰           ╯  ")),
-    AnimationFrame(("    ╭───────────╮  ", "    │  +        │  ", "    ╰───────────╯  ")),
-    AnimationFrame(("    ╭───────────╮  ", "    │  + graph/ │  ", "    ╰───────────╯  ")),
-    AnimationFrame(("    ╭───────────╮  ", "    │  ✓ config │  ", "    ╰───────────╯  ")),
-    AnimationFrame(("    ╭───────────╮  ", "    │ ✓ PROJECT │  ", "    ╰───────────╯  "), 0.12),
-)
+# Each command reveals its own pipeline during the intro, so the animation
+# doubles as a preview of what the command is about to do.
+_SIGNATURES: dict[str, tuple[str, ...]] = {
+    "api": ("config", "runtime", "server", "ready"),
+    "dev": ("config", "runtime", "server", "playground"),
+    "play": ("config", "runtime", "server", "playground"),
+    "init": ("template", "graph", "config", "project"),
+    "build": ("source", "deps", "image", "ship"),
+    "test": ("collect", "run", "assert", "report"),
+    "eval": ("discover", "load", "score", "report"),
+    "doctor": ("python", "core", "config", "port"),
+    "skills": ("detect", "resolve", "install", "activate"),
+}
+_DEFAULT_SIGNATURE = ("boot", "load", "ready")
 
-_SCAFFOLD_ASCII_FRAMES = (
-    AnimationFrame(("    +           +  ", "                   ", "    +           +  ")),
-    AnimationFrame(("    +-----------+  ", "    |  +        |  ", "    +-----------+  ")),
-    AnimationFrame(("    +-----------+  ", "    |  + graph/ |  ", "    +-----------+  ")),
-    AnimationFrame(("    +-----------+  ", "    |  OK config|  ", "    +-----------+  ")),
-    AnimationFrame(("    +-----------+  ", "    | OK PROJECT|  ", "    +-----------+  "), 0.12),
-)
-
-_PIPELINE_UNICODE_FRAMES = (
-    AnimationFrame(("  source  ·  image  ·  ship ", "          ░░░░░░░░        ")),
-    AnimationFrame(("  source  ◆  image  ·  ship ", "          ██░░░░░░        ")),
-    AnimationFrame(("  source  ◆  image  ◆  ship ", "          █████░░░        ")),
-    AnimationFrame(("  source  ◆  image  ◆  ship ", "          ████████        "), 0.12),
-)
-
-_PIPELINE_ASCII_FRAMES = (
-    AnimationFrame(("  source  .  image  .  ship ", "          [        ]      ")),
-    AnimationFrame(("  source  O  image  .  ship ", "          [==      ]      ")),
-    AnimationFrame(("  source  O  image  O  ship ", "          [=====   ]      ")),
-    AnimationFrame(("  source  O  image  O  ship ", "          [========]      "), 0.12),
-)
-
-_CHECK_UNICODE_FRAMES = (
-    AnimationFrame(("    ◌  ◌  ◌  ◌       ", "    scanning…          ")),
-    AnimationFrame(("    ●  ◌  ◌  ◌       ", "    evaluating…        ")),
-    AnimationFrame(("    ✓  ●  ◌  ◌       ", "    evaluating…        ")),
-    AnimationFrame(("    ✓  ✓  ●  ◌       ", "    scoring…           ")),
-    AnimationFrame(("    ✓  ✓  ✓  ✓       ", "    all checks complete"), 0.12),
-)
-
-_CHECK_ASCII_FRAMES = (
-    AnimationFrame(("    o  o  o  o       ", "    scanning...        ")),
-    AnimationFrame(("    O  o  o  o       ", "    evaluating...      ")),
-    AnimationFrame(("    OK O  o  o       ", "    evaluating...      ")),
-    AnimationFrame(("    OK OK O  o       ", "    scoring...         ")),
-    AnimationFrame(("    OK OK OK OK      ", "    checks complete    "), 0.12),
-)
+_TAGLINES: dict[str, str] = {
+    "api": "Serving your agent over REST and WebSocket.",
+    "dev": "Local agent runtime with live reload.",
+    "play": "Local agent runtime, wired to the playground.",
+    "init": "Scaffolding a production-shaped agent project.",
+    "build": "Packaging your agent for deployment.",
+    "test": "Exercising your agent's test suite.",
+    "eval": "Scoring your agent against evaluation sets.",
+    "doctor": "Inspecting your Agentflow environment.",
+}
+_DEFAULT_TAGLINE = "Build, run, and inspect intelligent agent systems."
 
 
 def render_command_intro(
@@ -118,162 +94,339 @@ def render_command_intro(
     unicode: bool,
     persistent_screen: bool = False,
 ) -> None:
-    """Play a short best-effort intro and leave a useful static final frame."""
-    if command.lower() in {"play", "dev", "typing"}:
-        render_typing_splash(
+    """Play the command intro on the full canvas.
+
+    ``persistent_screen`` means the caller already owns an alternate screen that
+    it intends to keep. The sequence then plays in place and skips the durable
+    header, because the caller pins its own chrome once the intro finishes.
+    """
+    glyphs = glyphs_for(unicode)
+    if _can_play_cinematic(console):
+        _play_cinematic(
             console,
             command=command,
             subtitle=subtitle,
-            unicode=unicode,
-            persistent_screen=persistent_screen,
+            glyphs=glyphs,
+            own_screen=not persistent_screen,
         )
-        console.print(_final_renderable(command, subtitle, unicode))
+    else:
+        _play_inline(console, command=command, glyphs=glyphs)
+
+    if persistent_screen:
         return
 
-    frames = _frames_for(command, unicode)
-    with Live(
-        _frame_renderable(frames[0], command, subtitle),
-        console=console,
-        refresh_per_second=15,
-        transient=True,
-        redirect_stdout=False,
-        redirect_stderr=False,
-    ) as live:
-        for frame in frames:
-            live.update(_frame_renderable(frame, command, subtitle), refresh=True)
-            time.sleep(frame.duration)
-
-    console.print(_final_renderable(command, subtitle, unicode))
+    render_session_header(
+        console,
+        command=command,
+        subtitle=subtitle,
+        glyphs=glyphs,
+        version=CLI_VERSION,
+    )
 
 
-def render_typing_splash(
+def render_session_header(
     console: Console,
     *,
     command: str,
     subtitle: str | None,
-    unicode: bool,
-    persistent_screen: bool = False,
+    glyphs: Glyphs,
+    version: str | None = None,
 ) -> None:
-    """Use the terminal's alternate screen for a full-canvas typing reveal."""
-    word = "AGENTFLOW"
-    cursor = "▌" if unicode else "|"
-    visible_states = [word[:index] for index in range(len(word) + 1)]
-    visible_states.extend((word, word))
+    """Print the persistent branded band that identifies the running command."""
+    width = _usable_width(console)
+    console.print(gradient_rule(width, glyphs=glyphs))
 
+    identity = Text(" ", style="agentflow.header")
+    identity.append(f"{glyphs.diamond} ", style="agentflow.brand")
+    identity.append_text(gradient_text("agentflow", bold=True))
+    identity.append(f" {glyphs.caret} ", style="agentflow.muted")
+    identity.append(command, style="agentflow.command")
+    if version:
+        identity.append(" " * max(width - identity.cell_len - len(version) - 1, 1))
+        identity.append(version, style="agentflow.muted")
+    _pad_to_width(identity, width)
+    console.print(identity)
+
+    if subtitle:
+        caption = Text(" ", style="agentflow.header")
+        caption.append(subtitle, style="agentflow.muted")
+        _pad_to_width(caption, width)
+        console.print(caption)
+
+    console.print(gradient_rule(width, glyphs=glyphs, thin=True, offset=0.35))
+    console.print()
+
+
+def _can_play_cinematic(console: Console) -> bool:
+    return (
+        console.is_terminal
+        and console.height >= _MIN_CINEMATIC_HEIGHT
+        and console.width >= _MIN_CINEMATIC_WIDTH
+    )
+
+
+def _play_cinematic(
+    console: Console,
+    *,
+    command: str,
+    subtitle: str | None,
+    glyphs: Glyphs,
+) -> None:
+    """Run the full-canvas reveal on a temporary alternate screen."""
+    frame_interval = 1.0 / INTRO_FPS
+    frame_count = max(int(INTRO_DURATION_SECONDS * INTRO_FPS), 1)
+    tagline = _TAGLINES.get(command.lower(), subtitle or _DEFAULT_TAGLINE)
+
+    with (
+        console.screen(style="on #0b0b12", hide_cursor=True),
+        Live(
+            console=console,
+            auto_refresh=False,
+            transient=True,
+            redirect_stdout=False,
+            redirect_stderr=False,
+        ) as live,
+    ):
+        started = time.monotonic()
+        for frame in range(frame_count + 1):
+            progress = frame / frame_count
+            live.update(
+                _cinematic_frame(
+                    console,
+                    command=command,
+                    tagline=tagline,
+                    glyphs=glyphs,
+                    progress=progress,
+                ),
+                refresh=True,
+            )
+            # Sleep against the wall clock so a slow terminal shortens the
+            # sequence instead of stretching it past its motion budget.
+            target = started + (frame + 1) * frame_interval
+            remaining = target - time.monotonic()
+            if remaining > 0:
+                time.sleep(remaining)
+
+
+def _play_inline(console: Console, *, command: str, glyphs: Glyphs) -> None:
+    """Short in-buffer reveal for short terminals and nested screens."""
+    frame_count = 12
     with Live(
-        _typing_renderable(
-            console,
-            visible="",
-            cursor=cursor,
-            show_cursor=True,
-            command=command,
-            subtitle=subtitle,
-            unicode=unicode,
-        ),
         console=console,
-        screen=not persistent_screen,
         auto_refresh=False,
         transient=True,
         redirect_stdout=False,
         redirect_stderr=False,
     ) as live:
-        for index, visible in enumerate(visible_states):
-            show_cursor = index < len(word) or index % 2 == 0
+        for frame in range(frame_count + 1):
+            progress = frame / frame_count
             live.update(
-                _typing_renderable(
-                    console,
-                    visible=visible,
-                    cursor=cursor,
-                    show_cursor=show_cursor,
-                    command=command,
-                    subtitle=subtitle,
-                    unicode=unicode,
+                Group(
+                    Align.center(_compact_wordmark(progress, glyphs)),
+                    Align.center(_signature_nodes(command, progress, glyphs)),
                 ),
                 refresh=True,
             )
-            time.sleep(0.075 if index <= len(word) else 0.16)
+            time.sleep(0.045)
 
 
-def _typing_renderable(
+def _cinematic_frame(
     console: Console,
     *,
-    visible: str,
-    cursor: str,
-    show_cursor: bool,
     command: str,
-    subtitle: str | None,
-    unicode: bool,
+    tagline: str,
+    glyphs: Glyphs,
+    progress: float,
 ) -> RenderableType:
-    node = "◆" if unicode else "O"
-    rail = "━━━━" if unicode else "===="
-    eyebrow = Text(f"{node}{rail} AGENT RUNTIME {rail}{node}", style="bold magenta")
-    typed = Text(" ".join(visible), style="bold bright_cyan")
-    if show_cursor:
-        typed.append(cursor, style="bold white")
-    description = Text(
-        subtitle or "Build, run, and inspect intelligent agent systems.",
-        style="white",
-    )
-    mode = Text(f"agentflow {command}", style="dim cyan")
-    hint = Text("Preparing your interactive workspace…", style="dim white")
-    content = Group(
-        Align.center(eyebrow),
+    """Compose one frame of the intro from its independently timed layers."""
+    width = _usable_width(console)
+    reveal = _ease_out(_phase(progress, 0.05, 0.55))
+    shimmer = _phase(progress, 0.45, 0.9)
+    chrome = _phase(progress, 0.55, 0.85)
+    typing = _phase(progress, 0.6, 0.95)
+    pipeline = _phase(progress, 0.25, 1.0)
+
+    layers: list[RenderableType] = [
+        Align.center(_aurora(width, progress, glyphs, rows=2)),
         Text(""),
-        Align.center(typed),
-        Text(""),
-        Align.center(description),
-        Text(""),
-        Align.center(mode),
-        Text(""),
-        Align.center(hint),
-    )
+    ]
+    layers.extend(Align.center(line) for line in _block_wordmark(reveal, shimmer, glyphs))
+    layers.append(Text(""))
+
+    if chrome > 0:
+        layers.append(Align.center(_command_chip(command, chrome, glyphs)))
+        layers.append(Text(""))
+    if typing > 0:
+        layers.append(Align.center(_typed(tagline, typing, glyphs)))
+        layers.append(Text(""))
+
+    layers.append(Align.center(_signature_nodes(command, pipeline, glyphs)))
+    layers.append(Align.center(_signature_labels(command, pipeline)))
+    layers.append(Text(""))
+    layers.append(Align.center(_load_bar(progress, glyphs, width=min(width - 8, 44))))
+
     return Align.center(
-        content,
+        Group(*layers),
         vertical="middle",
-        height=max(console.height, 12),
-        style="on grey3",
+        height=max(console.height - 1, 12),
+        style="on #0b0b12",
     )
 
 
-def _frames_for(command: str, unicode: bool) -> tuple[AnimationFrame, ...]:
-    normalized = command.lower()
-    if normalized in {"api", "dev", "play"}:
-        return _NETWORK_UNICODE_FRAMES if unicode else _NETWORK_ASCII_FRAMES
-    if normalized == "init":
-        return _SCAFFOLD_UNICODE_FRAMES if unicode else _SCAFFOLD_ASCII_FRAMES
-    if normalized == "build":
-        return _PIPELINE_UNICODE_FRAMES if unicode else _PIPELINE_ASCII_FRAMES
-    if normalized in {"eval", "test"}:
-        return _CHECK_UNICODE_FRAMES if unicode else _CHECK_ASCII_FRAMES
-    return _BRAND_UNICODE_FRAMES if unicode else _BRAND_ASCII_FRAMES
+def _block_wordmark(reveal: float, shimmer: float, glyphs: Glyphs) -> list[Text]:
+    """Render AGENTFLOW as block letters swept in by a moving light front."""
+    if glyphs.block != "█":
+        return [_compact_wordmark(reveal, glyphs)]
+
+    columns = _wordmark_columns()
+    total = len(columns[0])
+    front = reveal * (total + 6) - 3
+    shimmer_front = shimmer * (total + 10) - 5
+
+    lines: list[Text] = []
+    for row in range(_BLOCK_ROWS):
+        line = Text()
+        for index in range(total):
+            character = columns[row][index]
+            if character == " " or index > front:
+                line.append(" ")
+                continue
+            distance = front - index
+            shimmer_distance = abs(shimmer_front - index)
+            if distance < _REVEAL_FRONT_WIDTH:
+                line.append(character, style="bold #ffffff")
+            elif shimmer > 0 and shimmer_distance < _SHIMMER_WIDTH:
+                line.append(character, style="bold #f5f3ff")
+            else:
+                line.append(character, style=f"bold {sample_ramp(index / total)}")
+        lines.append(line)
+    return lines
 
 
-def _frame_renderable(
-    frame: AnimationFrame,
-    command: str,
-    subtitle: str | None,
-) -> RenderableType:
-    art = Text("\n".join(frame.lines), style="agentflow.brand")
-    label = Text.assemble(
-        ("  agentflow ", "agentflow.title"),
-        (command, "agentflow.command"),
-    )
-    parts: list[RenderableType] = [Align.center(art), Align.center(label)]
-    if subtitle:
-        parts.append(Align.center(Text(subtitle, style="agentflow.muted")))
-    return Group(*parts)
+def _wordmark_columns() -> tuple[str, ...]:
+    """Lay the block font out once per row, letters separated by a column."""
+    rows: list[str] = []
+    for row in range(_BLOCK_ROWS):
+        rows.append(" ".join(_BLOCK_FONT[letter][row] for letter in _WORDMARK))
+    return tuple(rows)
 
 
-def _final_renderable(command: str, subtitle: str | None, unicode: bool) -> RenderableType:
-    connector = "◆" if unicode else "O"
-    line = Text.assemble(
-        (f"{connector} ", "agentflow.brand"),
-        ("agentflow", "agentflow.title"),
-        (" / ", "agentflow.muted"),
-        (command, "agentflow.command"),
-        (f" {connector}", "agentflow.brand"),
-    )
-    parts: list[RenderableType] = [Align.center(line)]
-    if subtitle:
-        parts.append(Align.center(Text(subtitle, style="agentflow.muted")))
-    return Group(*parts)
+def _compact_wordmark(reveal: float, glyphs: Glyphs) -> Text:
+    """Spaced wordmark used when block letters do not fit or render."""
+    visible = max(int(reveal * len(_WORDMARK)), 0)
+    text = Text()
+    text.append_text(gradient_text(" ".join(_WORDMARK[:visible]), bold=True))
+    if visible < len(_WORDMARK):
+        text.append(glyphs.cursor, style="bold #ffffff")
+    return text
+
+
+def _command_chip(command: str, intensity: float, glyphs: Glyphs) -> Text:
+    """Pill showing which command the intro belongs to."""
+    color = dim_hex("#4c1d95", 0.35 + 0.65 * intensity)
+    chip = Text(style=f"on {color}")
+    chip.append(f"  {glyphs.diamond} ", style="#a78bfa")
+    chip.append(command.lower(), style="bold #f8fafc")
+    chip.append("  ")
+    return chip
+
+
+def _typed(value: str, progress: float, glyphs: Glyphs) -> Text:
+    """Type ``value`` out one character at a time with a blinking caret."""
+    visible = int(_ease_out(progress) * len(value))
+    text = Text(value[:visible], style="#cbd5f5")
+    if visible < len(value) or int(progress * 12) % 2 == 0:
+        text.append(glyphs.cursor, style="#22d3ee")
+    return text
+
+
+def _aurora(width: int, progress: float, glyphs: Glyphs, *, rows: int) -> Text:
+    """Soft moving shade field that gives the canvas depth behind the logo."""
+    span = min(width, 56)
+    # Skip the blank shade: the band should read as one flowing ribbon rather
+    # than a dotted line with holes punched through it.
+    tiers = glyphs.shades[1:]
+    text = Text()
+    for row in range(rows):
+        for column in range(span):
+            wave = math.sin((column / 7.0) + progress * 6.0 + row * 1.3)
+            level = int((wave + 1.0) / 2.0 * (len(tiers) - 1))
+            tint = dim_hex(sample_ramp(column / span), 0.30 + 0.20 * row)
+            text.append(tiers[level], style=tint)
+        if row < rows - 1:
+            text.append("\n")
+    return text
+
+
+def _signature_for(command: str) -> tuple[str, ...]:
+    return _SIGNATURES.get(command.lower(), _DEFAULT_SIGNATURE)
+
+
+def _signature_nodes(command: str, progress: float, glyphs: Glyphs) -> Text:
+    """Node-and-link chain that fills in as the intro advances."""
+    stages = _signature_for(command)
+    segments = len(stages) * 2 - 1
+    filled = progress * segments
+    text = Text()
+    for index in range(segments):
+        active = index < filled
+        position = index / max(segments - 1, 1)
+        color = sample_ramp(position) if active else "#3f3f56"
+        if index % 2 == 0:
+            text.append(glyphs.node if active else glyphs.pending, style=f"bold {color}")
+        else:
+            text.append(glyphs.rule * 3 if active else glyphs.thin_rule * 3, style=color)
+    return text
+
+
+def _signature_labels(command: str, progress: float) -> Text:
+    """Stage names under the chain, brightening in step with their node."""
+    stages = _signature_for(command)
+    reached = progress * len(stages)
+    text = Text()
+    for index, stage in enumerate(stages):
+        if index:
+            text.append("  ")
+        if index < reached:
+            text.append(stage, style=f"bold {sample_ramp(index / max(len(stages) - 1, 1))}")
+        else:
+            text.append(stage, style="#3f3f56")
+    return text
+
+
+def _load_bar(progress: float, glyphs: Glyphs, *, width: int) -> Text:
+    """Hairline meter showing how much of the intro remains."""
+    span = max(width, 10)
+    filled = int(progress * span)
+    text = Text()
+    for index in range(span):
+        if index < filled:
+            text.append(glyphs.thin_rule, style=sample_ramp(index / span, BRAND_RAMP))
+        else:
+            text.append(glyphs.thin_rule, style="#242438")
+    return text
+
+
+def _phase(progress: float, start: float, end: float) -> float:
+    """Map a global timeline position into one layer's local ``0..1`` window."""
+    if progress <= start:
+        return 0.0
+    if progress >= end:
+        return 1.0
+    return (progress - start) / (end - start)
+
+
+def _ease_out(value: float) -> float:
+    """Cubic ease-out; motion decelerates instead of stopping abruptly."""
+    clamped = min(max(value, 0.0), 1.0)
+    return 1.0 - (1.0 - clamped) ** 3
+
+
+def _usable_width(console: Console) -> int:
+    return max(min(console.width, 100) - 1, 20)
+
+
+def _pad_to_width(text: Text, width: int) -> None:
+    padding = width - text.cell_len
+    if padding > 0:
+        text.append(" " * padding)

--- a/agentflow_cli/cli/core/animations.py
+++ b/agentflow_cli/cli/core/animations.py
@@ -1,0 +1,103 @@
+"""Terminal-native animation assets and renderers.
+
+Frames stay independent from colors so terminal themes and accessibility
+preferences can decide how semantic roles are rendered at runtime.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from rich.align import Align
+from rich.console import Console, Group, RenderableType
+from rich.live import Live
+from rich.text import Text
+
+
+@dataclass(frozen=True)
+class AnimationFrame:
+    """One terminal animation frame with its display duration."""
+
+    lines: tuple[str, ...]
+    duration: float = 0.07
+
+
+_UNICODE_FRAMES = (
+    AnimationFrame(("                    ", "         ·          ", "                    ")),
+    AnimationFrame(("                    ", "       ·─◆─·        ", "                    ")),
+    AnimationFrame(("       ╭───╮        ", "       │ ◆ │        ", "       ╰───╯        ")),
+    AnimationFrame(("   ◆───╭───╮───◆    ", "       │ A │        ", "   ◆───╰───╯───◆    ")),
+    AnimationFrame(("   ◆───╭───╮───◆    ", "       │ AF│  AGENT ", "   ◆───╰───╯───◆    ")),
+    AnimationFrame(
+        ("   ◆───╭───╮───◆    ", "       │ AF│  AGENTFLOW", "   ◆───╰───╯───◆    "),
+        0.12,
+    ),
+)
+
+_ASCII_FRAMES = (
+    AnimationFrame(("                    ", "         .          ", "                    ")),
+    AnimationFrame(("                    ", "       .-O-.        ", "                    ")),
+    AnimationFrame(("       +---+        ", "       | O |        ", "       +---+        ")),
+    AnimationFrame(("   O---+---+---O    ", "       | A |        ", "   O---+---+---O    ")),
+    AnimationFrame(("   O---+---+---O    ", "       | AF|  AGENT ", "   O---+---+---O    ")),
+    AnimationFrame(
+        ("   O---+---+---O    ", "       | AF|  AGENTFLOW", "   O---+---+---O    "),
+        0.12,
+    ),
+)
+
+
+def render_command_intro(
+    console: Console,
+    *,
+    command: str,
+    subtitle: str | None,
+    unicode: bool,
+) -> None:
+    """Play a short best-effort intro and leave a useful static final frame."""
+    frames = _UNICODE_FRAMES if unicode else _ASCII_FRAMES
+    with Live(
+        _frame_renderable(frames[0], command, subtitle),
+        console=console,
+        refresh_per_second=15,
+        transient=True,
+        redirect_stdout=False,
+        redirect_stderr=False,
+    ) as live:
+        for frame in frames:
+            live.update(_frame_renderable(frame, command, subtitle), refresh=True)
+            time.sleep(frame.duration)
+
+    console.print(_final_renderable(command, subtitle, unicode))
+
+
+def _frame_renderable(
+    frame: AnimationFrame,
+    command: str,
+    subtitle: str | None,
+) -> RenderableType:
+    art = Text("\n".join(frame.lines), style="agentflow.brand")
+    label = Text.assemble(
+        ("  agentflow ", "agentflow.title"),
+        (command, "agentflow.command"),
+    )
+    parts: list[RenderableType] = [Align.center(art), Align.center(label)]
+    if subtitle:
+        parts.append(Align.center(Text(subtitle, style="agentflow.muted")))
+    return Group(*parts)
+
+
+def _final_renderable(command: str, subtitle: str | None, unicode: bool) -> RenderableType:
+    connector = "◆" if unicode else "O"
+    line = Text.assemble(
+        (f"{connector} ", "agentflow.brand"),
+        ("agentflow", "agentflow.title"),
+        (" / ", "agentflow.muted"),
+        (command, "agentflow.command"),
+        (f" {connector}", "agentflow.brand"),
+    )
+    parts: list[RenderableType] = [Align.center(line)]
+    if subtitle:
+        parts.append(Align.center(Text(subtitle, style="agentflow.muted")))
+    return Group(*parts)

--- a/agentflow_cli/cli/core/animations.py
+++ b/agentflow_cli/cli/core/animations.py
@@ -23,7 +23,7 @@ class AnimationFrame:
     duration: float = 0.07
 
 
-_UNICODE_FRAMES = (
+_BRAND_UNICODE_FRAMES = (
     AnimationFrame(("                    ", "         ·          ", "                    ")),
     AnimationFrame(("                    ", "       ·─◆─·        ", "                    ")),
     AnimationFrame(("       ╭───╮        ", "       │ ◆ │        ", "       ╰───╯        ")),
@@ -35,7 +35,7 @@ _UNICODE_FRAMES = (
     ),
 )
 
-_ASCII_FRAMES = (
+_BRAND_ASCII_FRAMES = (
     AnimationFrame(("                    ", "         .          ", "                    ")),
     AnimationFrame(("                    ", "       .-O-.        ", "                    ")),
     AnimationFrame(("       +---+        ", "       | O |        ", "       +---+        ")),
@@ -47,6 +47,68 @@ _ASCII_FRAMES = (
     ),
 )
 
+_NETWORK_UNICODE_FRAMES = (
+    AnimationFrame(("        ◌          ", "        │          ", "    ◌───◆───◌      ")),
+    AnimationFrame(("        ◉          ", "        ┃          ", "    ◌───◆───◌      ")),
+    AnimationFrame(("        ◌          ", "        │          ", "    ◉━━━◆━━━◉      ")),
+    AnimationFrame(("    ◌───◆───◌      ", "        ┃          ", "    ◉━━━◆━━━◉      ")),
+    AnimationFrame(("    ◉━━━◆━━━◉      ", "        ┃          ", "    ◉━━━◆━━━◉      "), 0.12),
+)
+
+_NETWORK_ASCII_FRAMES = (
+    AnimationFrame(("        o          ", "        |          ", "    o---O---o      ")),
+    AnimationFrame(("        O          ", "        |          ", "    o---O---o      ")),
+    AnimationFrame(("        o          ", "        |          ", "    O===O===O      ")),
+    AnimationFrame(("    o---O---o      ", "        |          ", "    O===O===O      ")),
+    AnimationFrame(("    O===O===O      ", "        |          ", "    O===O===O      "), 0.12),
+)
+
+_SCAFFOLD_UNICODE_FRAMES = (
+    AnimationFrame(("    ╭           ╮  ", "                   ", "    ╰           ╯  ")),
+    AnimationFrame(("    ╭───────────╮  ", "    │  +        │  ", "    ╰───────────╯  ")),
+    AnimationFrame(("    ╭───────────╮  ", "    │  + graph/ │  ", "    ╰───────────╯  ")),
+    AnimationFrame(("    ╭───────────╮  ", "    │  ✓ config │  ", "    ╰───────────╯  ")),
+    AnimationFrame(("    ╭───────────╮  ", "    │ ✓ PROJECT │  ", "    ╰───────────╯  "), 0.12),
+)
+
+_SCAFFOLD_ASCII_FRAMES = (
+    AnimationFrame(("    +           +  ", "                   ", "    +           +  ")),
+    AnimationFrame(("    +-----------+  ", "    |  +        |  ", "    +-----------+  ")),
+    AnimationFrame(("    +-----------+  ", "    |  + graph/ |  ", "    +-----------+  ")),
+    AnimationFrame(("    +-----------+  ", "    |  OK config|  ", "    +-----------+  ")),
+    AnimationFrame(("    +-----------+  ", "    | OK PROJECT|  ", "    +-----------+  "), 0.12),
+)
+
+_PIPELINE_UNICODE_FRAMES = (
+    AnimationFrame(("  source  ·  image  ·  ship ", "          ░░░░░░░░        ")),
+    AnimationFrame(("  source  ◆  image  ·  ship ", "          ██░░░░░░        ")),
+    AnimationFrame(("  source  ◆  image  ◆  ship ", "          █████░░░        ")),
+    AnimationFrame(("  source  ◆  image  ◆  ship ", "          ████████        "), 0.12),
+)
+
+_PIPELINE_ASCII_FRAMES = (
+    AnimationFrame(("  source  .  image  .  ship ", "          [        ]      ")),
+    AnimationFrame(("  source  O  image  .  ship ", "          [==      ]      ")),
+    AnimationFrame(("  source  O  image  O  ship ", "          [=====   ]      ")),
+    AnimationFrame(("  source  O  image  O  ship ", "          [========]      "), 0.12),
+)
+
+_CHECK_UNICODE_FRAMES = (
+    AnimationFrame(("    ◌  ◌  ◌  ◌       ", "    scanning…          ")),
+    AnimationFrame(("    ●  ◌  ◌  ◌       ", "    evaluating…        ")),
+    AnimationFrame(("    ✓  ●  ◌  ◌       ", "    evaluating…        ")),
+    AnimationFrame(("    ✓  ✓  ●  ◌       ", "    scoring…           ")),
+    AnimationFrame(("    ✓  ✓  ✓  ✓       ", "    all checks complete"), 0.12),
+)
+
+_CHECK_ASCII_FRAMES = (
+    AnimationFrame(("    o  o  o  o       ", "    scanning...        ")),
+    AnimationFrame(("    O  o  o  o       ", "    evaluating...      ")),
+    AnimationFrame(("    OK O  o  o       ", "    evaluating...      ")),
+    AnimationFrame(("    OK OK O  o       ", "    scoring...         ")),
+    AnimationFrame(("    OK OK OK OK      ", "    checks complete    "), 0.12),
+)
+
 
 def render_command_intro(
     console: Console,
@@ -54,9 +116,21 @@ def render_command_intro(
     command: str,
     subtitle: str | None,
     unicode: bool,
+    persistent_screen: bool = False,
 ) -> None:
     """Play a short best-effort intro and leave a useful static final frame."""
-    frames = _UNICODE_FRAMES if unicode else _ASCII_FRAMES
+    if command.lower() in {"play", "dev", "typing"}:
+        render_typing_splash(
+            console,
+            command=command,
+            subtitle=subtitle,
+            unicode=unicode,
+            persistent_screen=persistent_screen,
+        )
+        console.print(_final_renderable(command, subtitle, unicode))
+        return
+
+    frames = _frames_for(command, unicode)
     with Live(
         _frame_renderable(frames[0], command, subtitle),
         console=console,
@@ -70,6 +144,108 @@ def render_command_intro(
             time.sleep(frame.duration)
 
     console.print(_final_renderable(command, subtitle, unicode))
+
+
+def render_typing_splash(
+    console: Console,
+    *,
+    command: str,
+    subtitle: str | None,
+    unicode: bool,
+    persistent_screen: bool = False,
+) -> None:
+    """Use the terminal's alternate screen for a full-canvas typing reveal."""
+    word = "AGENTFLOW"
+    cursor = "▌" if unicode else "|"
+    visible_states = [word[:index] for index in range(len(word) + 1)]
+    visible_states.extend((word, word))
+
+    with Live(
+        _typing_renderable(
+            console,
+            visible="",
+            cursor=cursor,
+            show_cursor=True,
+            command=command,
+            subtitle=subtitle,
+            unicode=unicode,
+        ),
+        console=console,
+        screen=not persistent_screen,
+        auto_refresh=False,
+        transient=True,
+        redirect_stdout=False,
+        redirect_stderr=False,
+    ) as live:
+        for index, visible in enumerate(visible_states):
+            show_cursor = index < len(word) or index % 2 == 0
+            live.update(
+                _typing_renderable(
+                    console,
+                    visible=visible,
+                    cursor=cursor,
+                    show_cursor=show_cursor,
+                    command=command,
+                    subtitle=subtitle,
+                    unicode=unicode,
+                ),
+                refresh=True,
+            )
+            time.sleep(0.075 if index <= len(word) else 0.16)
+
+
+def _typing_renderable(
+    console: Console,
+    *,
+    visible: str,
+    cursor: str,
+    show_cursor: bool,
+    command: str,
+    subtitle: str | None,
+    unicode: bool,
+) -> RenderableType:
+    node = "◆" if unicode else "O"
+    rail = "━━━━" if unicode else "===="
+    eyebrow = Text(f"{node}{rail} AGENT RUNTIME {rail}{node}", style="bold magenta")
+    typed = Text(" ".join(visible), style="bold bright_cyan")
+    if show_cursor:
+        typed.append(cursor, style="bold white")
+    description = Text(
+        subtitle or "Build, run, and inspect intelligent agent systems.",
+        style="white",
+    )
+    mode = Text(f"agentflow {command}", style="dim cyan")
+    hint = Text("Preparing your interactive workspace…", style="dim white")
+    content = Group(
+        Align.center(eyebrow),
+        Text(""),
+        Align.center(typed),
+        Text(""),
+        Align.center(description),
+        Text(""),
+        Align.center(mode),
+        Text(""),
+        Align.center(hint),
+    )
+    return Align.center(
+        content,
+        vertical="middle",
+        height=max(console.height, 12),
+        style="on grey3",
+    )
+
+
+def _frames_for(command: str, unicode: bool) -> tuple[AnimationFrame, ...]:
+    normalized = command.lower()
+    if normalized in {"api", "dev", "play"}:
+        return _NETWORK_UNICODE_FRAMES if unicode else _NETWORK_ASCII_FRAMES
+    if normalized == "init":
+        return _SCAFFOLD_UNICODE_FRAMES if unicode else _SCAFFOLD_ASCII_FRAMES
+    if normalized == "build":
+        return _PIPELINE_UNICODE_FRAMES if unicode else _PIPELINE_ASCII_FRAMES
+    if normalized in {"eval", "test"}:
+        return _CHECK_UNICODE_FRAMES if unicode else _CHECK_ASCII_FRAMES
+    return _BRAND_UNICODE_FRAMES if unicode else _BRAND_ASCII_FRAMES
 
 
 def _frame_renderable(

--- a/agentflow_cli/cli/core/animations.py
+++ b/agentflow_cli/cli/core/animations.py
@@ -71,7 +71,7 @@ _SIGNATURES: dict[str, tuple[str, ...]] = {
     "build": ("source", "deps", "image", "ship"),
     "test": ("collect", "run", "assert", "report"),
     "eval": ("discover", "load", "score", "report"),
-    "doctor": ("python", "core", "config", "port"),
+    "audit": ("python", "core", "config", "port"),
     "skills": ("detect", "resolve", "install", "activate"),
 }
 _DEFAULT_SIGNATURE = ("boot", "load", "ready")
@@ -84,7 +84,7 @@ _TAGLINES: dict[str, str] = {
     "build": "Packaging your agent for deployment.",
     "test": "Exercising your agent's test suite.",
     "eval": "Scoring your agent against evaluation sets.",
-    "doctor": "Inspecting your Agentflow environment.",
+    "audit": "Auditing your Agentflow environment.",
 }
 _DEFAULT_TAGLINE = "Build, run, and inspect intelligent agent systems."
 

--- a/agentflow_cli/cli/core/config.py
+++ b/agentflow_cli/cli/core/config.py
@@ -45,13 +45,11 @@ class ConfigManager:
                 )
             return config_path_obj
 
-        # Search locations in order of preference
+        # Search the working directory and its parents first so commands invoked
+        # from a nested package still resolve the nearest Agentflow project.
         search_locations = [
-            # Current working directory
-            Path.cwd() / config_path,
-            # Relative to the CLI script location
+            *(directory / config_path for directory in self._working_tree()),
             Path(__file__).parent.parent / config_path,
-            # Project root
             PROJECT_ROOT / config_path,
         ]
 
@@ -83,10 +81,7 @@ class ConfigManager:
         Returns:
             Path to discovered config file or None if not found
         """
-        search_dirs = [
-            Path.cwd(),
-            PROJECT_ROOT,
-        ]
+        search_dirs = [*self._working_tree(), PROJECT_ROOT]
 
         for search_dir in search_dirs:
             for config_name in CONFIG_FILENAMES:
@@ -95,6 +90,12 @@ class ConfigManager:
                     return config_path
 
         return None
+
+    @staticmethod
+    def _working_tree() -> tuple[Path, ...]:
+        """Return cwd followed by its ancestors, nearest first."""
+        cwd = Path.cwd().resolve()
+        return (cwd, *cwd.parents)
 
     def load_config(self, config_path: str | None = None) -> dict[str, Any]:
         """Load configuration from file.

--- a/agentflow_cli/cli/core/output.py
+++ b/agentflow_cli/cli/core/output.py
@@ -1,31 +1,125 @@
-"""Output formatting utilities for the CLI."""
+"""Adaptive terminal output utilities for the CLI."""
 
 from __future__ import annotations
 
+import json
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any, TextIO
 
-import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.status import Status
+from rich.table import Table
+from rich.theme import Theme
 
-from agentflow_cli.cli.constants import (
-    EMOJI_ERROR,
-    EMOJI_INFO,
-    EMOJI_SPARKLE,
-    EMOJI_SUCCESS,
-    Colors,
+from agentflow_cli.cli.capabilities import (
+    ColorMode,
+    OutputFormat,
+    ProgressMode,
+    TerminalCapabilities,
+)
+
+
+_THEME = Theme(
+    {
+        "agentflow.success": "bold green",
+        "agentflow.error": "bold red",
+        "agentflow.warning": "bold yellow",
+        "agentflow.info": "cyan",
+        "agentflow.muted": "dim",
+        "agentflow.title": "bold magenta",
+    }
 )
 
 
 class OutputFormatter:
-    """Handles formatted output for the CLI."""
+    """Render semantic CLI output for terminals, pipes, and automation."""
 
-    def __init__(self, stream: TextIO | None = None) -> None:
-        """Initialize the output formatter.
+    def __init__(
+        self,
+        stream: TextIO | None = None,
+        *,
+        error_stream: TextIO | None = None,
+        output_format: OutputFormat = OutputFormat.HUMAN,
+        color_mode: ColorMode = ColorMode.AUTO,
+        progress_mode: ProgressMode = ProgressMode.AUTO,
+        quiet: bool = False,
+    ) -> None:
+        self._stream = stream
+        self._error_stream = error_stream
+        self.output_format = output_format
+        self.color_mode = color_mode
+        self.progress_mode = progress_mode
+        self.quiet = quiet
+        self.capabilities = TerminalCapabilities.detect(
+            stream=self.stream,
+            output_format=output_format,
+            color_mode=color_mode,
+            progress_mode=progress_mode,
+        )
 
-        Args:
-            stream: Output stream (defaults to stdout)
-        """
-        self.stream = stream or sys.stdout
+    @property
+    def stream(self) -> TextIO:
+        """Current stdout stream, remaining compatible with CliRunner capture."""
+        return self._stream or sys.stdout
+
+    @property
+    def error_stream(self) -> TextIO:
+        """Current stderr stream, or the explicit test stream when supplied."""
+        if self._error_stream is not None:
+            return self._error_stream
+        if self._stream is not None:
+            return self._stream
+        return sys.stderr
+
+    def configure(
+        self,
+        *,
+        output_format: OutputFormat | None = None,
+        color_mode: ColorMode | None = None,
+        progress_mode: ProgressMode | None = None,
+        quiet: bool | None = None,
+    ) -> None:
+        """Apply invocation-level rendering policy."""
+        if output_format is not None:
+            self.output_format = output_format
+        if color_mode is not None:
+            self.color_mode = color_mode
+        if progress_mode is not None:
+            self.progress_mode = progress_mode
+        if quiet is not None:
+            self.quiet = quiet
+        self.capabilities = TerminalCapabilities.detect(
+            stream=self.stream,
+            output_format=self.output_format,
+            color_mode=self.color_mode,
+            progress_mode=self.progress_mode,
+        )
+
+    def _console(self, *, error: bool = False) -> Console:
+        return Console(
+            file=self.error_stream if error else self.stream,
+            theme=_THEME,
+            no_color=not self.capabilities.color,
+            force_terminal=self.capabilities.color,
+            highlight=False,
+            soft_wrap=False,
+        )
+
+    @property
+    def _structured(self) -> bool:
+        return self.capabilities.output_format in {OutputFormat.JSON, OutputFormat.JSONL}
+
+    def _emit_event(self, event: str, message: str, **data: Any) -> None:
+        payload = {
+            "schema": "agentflow.cli/v1",
+            "type": event,
+            "message": message,
+            **data,
+        }
+        print(json.dumps(payload, ensure_ascii=False, default=str), file=self.stream, flush=True)
 
     def print_banner(
         self,
@@ -34,74 +128,70 @@ class OutputFormatter:
         color: str = "cyan",
         width: int = 50,
     ) -> None:
-        """Print a formatted banner.
+        """Render a compact section heading or a panel on an interactive terminal."""
+        if self.quiet:
+            return
+        if self._structured:
+            self._emit_event("section", title, subtitle=subtitle)
+            return
+        if self.capabilities.output_format == OutputFormat.PLAIN:
+            print(f"\n== {title} ==", file=self.stream)
+            if subtitle:
+                print(subtitle, file=self.stream)
+            print("", file=self.stream)
+            return
 
-        Args:
-            title: Banner title
-            subtitle: Optional subtitle
-            color: Color name for the banner
-            width: Banner width
-        """
-        colored_title = Colors.colorize(f"== {title} ==", color)
-
-        typer.echo("")
-        typer.echo(colored_title, file=self.stream)
+        body = f"[agentflow.title]{title}[/agentflow.title]"
         if subtitle:
-            typer.echo(subtitle, file=self.stream)
-        typer.echo("", file=self.stream)
+            body += f"\n[agentflow.muted]{subtitle}[/agentflow.muted]"
+        self._console().print(Panel.fit(body, border_style=color, padding=(0, 1), width=width))
 
     def success(self, message: str, emoji: bool = True) -> None:
-        """Print a success message.
-
-        Args:
-            message: Success message
-            emoji: Whether to include emoji
-        """
-        prefix = f"{EMOJI_SUCCESS}  " if emoji else ""
-        formatted = Colors.colorize(f"{prefix}{message}", "green")
-        typer.echo(f"\n{formatted}", file=self.stream)
+        if self.quiet:
+            return
+        symbol = "✓" if self.capabilities.unicode else "OK"
+        self._message("success", message, symbol if emoji else "", error=False)
 
     def error(self, message: str, emoji: bool = True) -> None:
-        """Print an error message.
-
-        Args:
-            message: Error message
-            emoji: Whether to include emoji
-        """
-        prefix = f"{EMOJI_ERROR}  " if emoji else ""
-        formatted = Colors.colorize(f"{prefix}{message}", "red")
-        typer.echo(f"\n{formatted}", err=True)
+        symbol = "✗" if self.capabilities.unicode else "X"
+        self._message("error", message, symbol if emoji else "", error=True)
 
     def info(self, message: str, emoji: bool = True) -> None:
-        """Print an info message.
-
-        Args:
-            message: Info message
-            emoji: Whether to include emoji
-        """
-        prefix = f"{EMOJI_INFO}  " if emoji else ""
-        formatted = Colors.colorize(f"{prefix}{message}", "blue")
-        typer.echo(f"\n{formatted}", file=self.stream)
+        if self.quiet:
+            return
+        self._message("info", message, "i" if emoji else "", error=False)
 
     def warning(self, message: str, emoji: bool = True) -> None:
-        """Print a warning message.
+        if self.quiet:
+            return
+        self._message("warning", message, "!" if emoji else "", error=False)
 
-        Args:
-            message: Warning message
-            emoji: Whether to include emoji
-        """
-        prefix = f"{EMOJI_ERROR}  " if emoji else ""
-        formatted = Colors.colorize(f"{prefix}{message}", "yellow")
-        typer.echo(f"\n{formatted}", file=self.stream)
+    def _message(
+        self,
+        level: str,
+        message: str,
+        symbol: str,
+        *,
+        error: bool,
+    ) -> None:
+        if self._structured:
+            self._emit_event(level, message)
+            return
+        prefix = f"{symbol} " if symbol else ""
+        if self.capabilities.output_format == OutputFormat.PLAIN:
+            print(f"{prefix}{message}", file=self.error_stream if error else self.stream)
+            return
+        self._console(error=error).print(f"[agentflow.{level}]{prefix}{message}[/agentflow.{level}]")
 
     def emphasize(self, message: str) -> None:
-        """Print an emphasized message with sparkle emoji.
-
-        Args:
-            message: Message to emphasize
-        """
-        formatted = f"{EMOJI_SPARKLE}  {message}"
-        typer.echo(f"\n{formatted}", file=self.stream)
+        if self.quiet:
+            return
+        self._message(
+            "info",
+            message,
+            "•" if self.capabilities.unicode else "*",
+            error=False,
+        )
 
     def print_list(
         self,
@@ -109,18 +199,16 @@ class OutputFormatter:
         title: str | None = None,
         bullet: str = "•",
     ) -> None:
-        """Print a formatted list.
-
-        Args:
-            items: List items to print
-            title: Optional list title
-            bullet: Bullet character
-        """
+        if self.quiet:
+            return
+        if self._structured:
+            self._emit_event("list", title or "", items=items)
+            return
+        console = self._console()
         if title:
-            typer.echo(f"\n{title}:", file=self.stream)
-
+            console.print(f"\n[bold]{title}[/bold]")
         for item in items:
-            typer.echo(f"  {bullet} {item}", file=self.stream)
+            console.print(f"  {bullet} {item}")
 
     def print_key_value_pairs(
         self,
@@ -128,19 +216,17 @@ class OutputFormatter:
         title: str | None = None,
         indent: int = 2,
     ) -> None:
-        """Print key-value pairs in a formatted way.
-
-        Args:
-            pairs: Dictionary of key-value pairs
-            title: Optional title for the section
-            indent: Indentation level
-        """
+        if self.quiet:
+            return
+        if self._structured:
+            self._emit_event("data", title or "", data=pairs)
+            return
+        console = self._console()
         if title:
-            typer.echo(f"\n{title}:", file=self.stream)
-
-        indent_str = " " * indent
+            console.print(f"\n[bold]{title}[/bold]")
+        pad = " " * indent
         for key, value in pairs.items():
-            typer.echo(f"{indent_str}{key}: {value}", file=self.stream)
+            console.print(f"{pad}[agentflow.muted]{key}[/agentflow.muted]  {value}")
 
     def print_table(
         self,
@@ -148,66 +234,60 @@ class OutputFormatter:
         rows: list[list[str]],
         title: str | None = None,
     ) -> None:
-        """Print a simple table.
+        if self.quiet:
+            return
+        if self._structured:
+            records = [
+                {
+                    header: row[index] if index < len(row) else ""
+                    for index, header in enumerate(headers)
+                }
+                for row in rows
+            ]
+            self._emit_event("table", title or "", columns=headers, rows=records)
+            return
 
-        Args:
-            headers: Table headers
-            rows: Table rows
-            title: Optional table title
-        """
-        if title:
-            typer.echo(f"\n{title}:", file=self.stream)
-
-        # Calculate column widths
-        all_rows = [headers, *rows]
-        col_widths = [
-            max(len(str(row[i])) for row in all_rows if i < len(row)) for i in range(len(headers))
-        ]
-
-        # Print headers
-        header_row = " | ".join(str(headers[i]).ljust(col_widths[i]) for i in range(len(headers)))
-        typer.echo(f"\n{header_row}", file=self.stream)
-        typer.echo("-" * len(header_row), file=self.stream)
-
-        # Print rows
+        table = Table(title=title, header_style="bold cyan", show_lines=False)
+        for header in headers:
+            table.add_column(str(header), overflow="fold")
         for row in rows:
-            row_str = " | ".join(
-                str(row[i] if i < len(row) else "").ljust(col_widths[i])
-                for i in range(len(headers))
-            )
-            typer.echo(row_str, file=self.stream)
+            table.add_row(*(str(row[i]) if i < len(row) else "" for i in range(len(headers))))
+        self._console().print(table)
+
+    @contextmanager
+    def status(self, message: str) -> Iterator[Status | None]:
+        """Show an indeterminate status when animation is safe."""
+        if self.quiet or not self.capabilities.animation:
+            if not self.quiet and self.capabilities.progress_mode == ProgressMode.PLAIN:
+                self.info(message, emoji=False)
+            yield None
+            return
+        with self._console().status(message, spinner="dots") as status:
+            yield status
 
 
-# Global instance for convenience
 output = OutputFormatter()
 
 
-# Convenience functions that use the global instance
 def print_banner(title: str, subtitle: str | None = None, color: str = "cyan") -> None:
-    """Print a formatted banner using the global formatter."""
     output.print_banner(title, subtitle, color)
 
 
 def success(message: str, emoji: bool = True) -> None:
-    """Print a success message using the global formatter."""
     output.success(message, emoji)
 
 
 def error(message: str, emoji: bool = True) -> None:
-    """Print an error message using the global formatter."""
     output.error(message, emoji)
 
 
 def info(message: str, emoji: bool = True) -> None:
-    """Print an info message using the global formatter."""
     output.info(message, emoji)
 
 
 def warning(message: str, emoji: bool = True) -> None:
-    """Print a warning message using the global formatter."""
     output.warning(message, emoji)
 
 
 def emphasize(message: str) -> None:
-    """Print an emphasized message using the global formatter."""
     output.emphasize(message)

--- a/agentflow_cli/cli/core/output.py
+++ b/agentflow_cli/cli/core/output.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import json
 import sys
 import time
@@ -26,6 +25,7 @@ from agentflow_cli.cli.capabilities import (
 )
 from agentflow_cli.cli.constants import CLI_VERSION
 from agentflow_cli.cli.core.animations import render_command_intro, render_session_header
+from agentflow_cli.cli.core.screen import AppFrame
 from agentflow_cli.cli.core.steps import (
     LiveProgressRun,
     LiveTimeline,
@@ -42,15 +42,8 @@ from agentflow_cli.cli.core.theme import (
     AGENTFLOW_THEME,
     Glyphs,
     glyphs_for,
-    gradient_rule,
     gradient_text,
 )
-
-
-# Paint the alternate buffer before anything renders into it, so opt-in
-# full-screen mode reads as a dedicated surface rather than a cleared prompt.
-_FULLSCREEN_PAINT = "\x1b[48;2;11;11;18m\x1b[2J\x1b[H"
-_FULLSCREEN_RESET = "\x1b[0m"
 
 
 class OutputFormatter:
@@ -73,7 +66,8 @@ class OutputFormatter:
         self.progress_mode = progress_mode
         self.quiet = quiet
         self._session_console: Console | None = None
-        self._screen_active: bool = False
+        self._frame: AppFrame | None = None
+        self._fullscreen_requested = False
         self._consoles: dict[bool, Console] = {}
         self.capabilities = TerminalCapabilities.detect(
             stream=self.stream,
@@ -152,67 +146,40 @@ class OutputFormatter:
     @property
     def fullscreen_active(self) -> bool:
         """Whether this invocation currently owns the alternate screen."""
-        return self._screen_active
+        return self._frame is not None and self._frame.active
+
+    def request_fullscreen(self, enabled: bool) -> None:
+        """Record whether this invocation may claim a full-screen surface.
+
+        The screen is not taken here. It is claimed lazily by the first
+        ``command_header`` call, so script-shaped commands — ``--version``,
+        ``config get`` — never take over the terminal or pause on exit.
+        """
+        self._fullscreen_requested = enabled
 
     def start_fullscreen_session(self) -> bool:
-        """Run the whole command on a painted alternate screen.
-
-        This switches the terminal buffer directly instead of wrapping the
-        session in a live display: a live display re-homes the cursor before
-        every write, which would overwrite each line the command prints.
-        """
+        """Claim the alternate screen for the whole command."""
         if self.fullscreen_active or self.quiet or not self.capabilities.animation:
             return False
+
         console = self._console()
-        if not console.is_terminal:
+        frame = AppFrame(console, glyphs=self.glyphs, color=self.capabilities.color)
+        if not frame.open():
             return False
 
-        console.set_alt_screen(True)
-        if self.capabilities.color:
-            console.file.write(_FULLSCREEN_PAINT)
-            console.file.flush()
+        # Bind every later render to this console so chrome, live displays, and
+        # ordinary prints all agree on where the cursor is.
         self._session_console = console
-        self._screen_active = True
+        self._frame = frame
         return True
 
     def end_fullscreen_session(self) -> None:
-        """Hold the alternate screen for review, then restore the terminal.
-
-        Releasing an alternate screen discards everything drawn on it, so the
-        session pauses first — otherwise a fast command would erase its own
-        result before the user could read it.
-        """
-        if not self._screen_active:
-            return
-        console = self._session_console
-        self._screen_active = False
+        """Pause on the closing hint, then restore the user's terminal."""
+        frame = self._frame
+        self._frame = None
         self._session_console = None
-        if console is None:
-            return
-
-        self._hold_for_review(console)
-        if self.capabilities.color:
-            console.file.write(_FULLSCREEN_RESET)
-            console.file.flush()
-        console.set_alt_screen(False)
-        console.show_cursor(True)
-
-    def _hold_for_review(self, console: Console) -> None:
-        glyphs = self.glyphs
-        console.print()
-        console.print(
-            gradient_rule(max(min(console.width, 100) - 1, 20), glyphs=glyphs, thin=True)
-        )
-        console.print(
-            Text(
-                f" {glyphs.caret} Press Enter to return to your terminal",
-                style="agentflow.muted",
-            )
-        )
-        if not sys.stdin.isatty():
-            return
-        with contextlib.suppress(Exception):
-            sys.stdin.readline()
+        if frame is not None:
+            frame.close()
 
     @property
     def _structured(self) -> bool:
@@ -258,8 +225,13 @@ class OutputFormatter:
         subtitle: str | None = None,
         *,
         color: str = "cyan",
+        hint: str | None = None,
     ) -> None:
-        """Render an animated command identity when the terminal supports it."""
+        """Render an animated command identity when the terminal supports it.
+
+        ``hint`` is the closing line pinned in the full-screen footer; it should
+        say how to leave whatever the command is about to do.
+        """
         if self.quiet:
             return
         if self._structured:
@@ -279,6 +251,8 @@ class OutputFormatter:
                 version=CLI_VERSION,
             )
             return
+        if self._fullscreen_requested:
+            self.start_fullscreen_session()
         render_command_intro(
             self._console(),
             command=command,
@@ -286,6 +260,15 @@ class OutputFormatter:
             unicode=self.capabilities.unicode,
             persistent_screen=self.fullscreen_active,
         )
+        if self._frame is not None:
+            # The intro owned the whole canvas; pin the chrome it collapses into
+            # and hand the body region over to the command's output.
+            self._frame.install_chrome(
+                command=command,
+                subtitle=subtitle,
+                version=CLI_VERSION,
+                hint=hint,
+            )
 
     def timeline(
         self,
@@ -371,7 +354,9 @@ class OutputFormatter:
         if self.capabilities.output_format == OutputFormat.PLAIN:
             print(f"{prefix}{message}", file=self.error_stream if error else self.stream)
             return
-        self._console(error=error).print(f"[agentflow.{level}]{prefix}{message}[/agentflow.{level}]")
+        self._console(error=error).print(
+            f"[agentflow.{level}]{prefix}{message}[/agentflow.{level}]"
+        )
 
     def emphasize(self, message: str) -> None:
         if self.quiet:

--- a/agentflow_cli/cli/core/output.py
+++ b/agentflow_cli/cli/core/output.py
@@ -59,6 +59,8 @@ class OutputFormatter:
         self.color_mode = color_mode
         self.progress_mode = progress_mode
         self.quiet = quiet
+        self._session_console: Console | None = None
+        self._screen_context: Any | None = None
         self.capabilities = TerminalCapabilities.detect(
             stream=self.stream,
             output_format=output_format,
@@ -105,6 +107,8 @@ class OutputFormatter:
         )
 
     def _console(self, *, error: bool = False) -> Console:
+        if self._session_console is not None:
+            return self._session_console
         return Console(
             file=self.error_stream if error else self.stream,
             theme=_THEME,
@@ -113,6 +117,35 @@ class OutputFormatter:
             highlight=False,
             soft_wrap=False,
         )
+
+    @property
+    def fullscreen_active(self) -> bool:
+        """Whether this invocation currently owns the alternate screen."""
+        return self._screen_context is not None
+
+    def start_fullscreen_session(self) -> bool:
+        """Enter a themed alternate screen for the full command lifetime."""
+        if self.fullscreen_active or self.quiet or not self.capabilities.animation:
+            return False
+        console = self._console()
+        screen_context = console.screen(style="on grey3", hide_cursor=False)
+        self._session_console = console
+        self._screen_context = screen_context
+        try:
+            screen_context.__enter__()
+        except Exception:
+            self._session_console = None
+            self._screen_context = None
+            raise
+        return True
+
+    def end_fullscreen_session(self) -> None:
+        """Restore the user's original terminal after a full-screen command."""
+        screen_context = self._screen_context
+        self._screen_context = None
+        self._session_console = None
+        if screen_context is not None:
+            screen_context.__exit__(None, None, None)
 
     @property
     def _structured(self) -> bool:
@@ -170,6 +203,7 @@ class OutputFormatter:
             command=command,
             subtitle=subtitle,
             unicode=self.capabilities.unicode,
+            persistent_screen=self.fullscreen_active,
         )
 
     def success(self, message: str, emoji: bool = True) -> None:

--- a/agentflow_cli/cli/core/output.py
+++ b/agentflow_cli/cli/core/output.py
@@ -25,6 +25,7 @@ from agentflow_cli.cli.capabilities import (
 )
 from agentflow_cli.cli.constants import CLI_VERSION
 from agentflow_cli.cli.core.animations import render_command_intro, render_session_header
+from agentflow_cli.cli.core.prompts import PromptService
 from agentflow_cli.cli.core.screen import AppFrame
 from agentflow_cli.cli.core.steps import (
     LiveProgressRun,
@@ -180,6 +181,18 @@ class OutputFormatter:
         self._session_console = None
         if frame is not None:
             frame.close()
+
+    def refresh_chrome(self) -> None:
+        """Repaint pinned chrome that something else may have drawn over."""
+        if self._frame is not None:
+            self._frame.redraw_chrome()
+
+    def prompts(self, *, interactive: bool | None = None) -> PromptService:
+        """Build a prompt service bound to this invocation's terminal state."""
+        return PromptService(
+            interactive=interactive,
+            on_answered=self.refresh_chrome,
+        )
 
     @property
     def _structured(self) -> bool:

--- a/agentflow_cli/cli/core/output.py
+++ b/agentflow_cli/cli/core/output.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import sys
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from typing import Any, TextIO
 
+from rich import box
 from rich.console import Console
+from rich.live import Live
 from rich.panel import Panel
 from rich.status import Status
 from rich.table import Table
 from rich.text import Text
-from rich.theme import Theme
 
 from agentflow_cli.cli.capabilities import (
     ColorMode,
@@ -22,22 +24,33 @@ from agentflow_cli.cli.capabilities import (
     ProgressMode,
     TerminalCapabilities,
 )
-from agentflow_cli.cli.core.animations import render_command_intro
-
-
-_THEME = Theme(
-    {
-        "agentflow.success": "bold green",
-        "agentflow.error": "bold red",
-        "agentflow.warning": "bold yellow",
-        "agentflow.info": "cyan",
-        "agentflow.muted": "dim",
-        "agentflow.title": "bold magenta",
-        "agentflow.brand": "bold cyan",
-        "agentflow.command": "bold white",
-        "agentflow.progress": "cyan",
-    }
+from agentflow_cli.cli.constants import CLI_VERSION
+from agentflow_cli.cli.core.animations import render_command_intro, render_session_header
+from agentflow_cli.cli.core.steps import (
+    LiveProgressRun,
+    LiveTimeline,
+    ProgressRun,
+    QuietProgressRun,
+    QuietTimeline,
+    StaticProgressRun,
+    StaticTimeline,
+    StructuredProgressRun,
+    StructuredTimeline,
+    Timeline,
 )
+from agentflow_cli.cli.core.theme import (
+    AGENTFLOW_THEME,
+    Glyphs,
+    glyphs_for,
+    gradient_rule,
+    gradient_text,
+)
+
+
+# Paint the alternate buffer before anything renders into it, so opt-in
+# full-screen mode reads as a dedicated surface rather than a cleared prompt.
+_FULLSCREEN_PAINT = "\x1b[48;2;11;11;18m\x1b[2J\x1b[H"
+_FULLSCREEN_RESET = "\x1b[0m"
 
 
 class OutputFormatter:
@@ -60,7 +73,8 @@ class OutputFormatter:
         self.progress_mode = progress_mode
         self.quiet = quiet
         self._session_console: Console | None = None
-        self._screen_context: Any | None = None
+        self._screen_active: bool = False
+        self._consoles: dict[bool, Console] = {}
         self.capabilities = TerminalCapabilities.detect(
             stream=self.stream,
             output_format=output_format,
@@ -99,6 +113,8 @@ class OutputFormatter:
             self.progress_mode = progress_mode
         if quiet is not None:
             self.quiet = quiet
+        # Color and terminal policy are baked into a Console at construction.
+        self._consoles.clear()
         self.capabilities = TerminalCapabilities.detect(
             stream=self.stream,
             output_format=self.output_format,
@@ -107,45 +123,96 @@ class OutputFormatter:
         )
 
     def _console(self, *, error: bool = False) -> Console:
+        """Return the one console bound to this stream.
+
+        Consoles are cached rather than rebuilt per call because a Rich live
+        display only knows to render ordinary prints *above* itself when those
+        prints go through the same console instance.
+        """
         if self._session_console is not None:
             return self._session_console
-        return Console(
-            file=self.error_stream if error else self.stream,
-            theme=_THEME,
-            no_color=not self.capabilities.color,
-            force_terminal=self.capabilities.color,
-            highlight=False,
-            soft_wrap=False,
-        )
+        cached = self._consoles.get(error)
+        if cached is None:
+            cached = Console(
+                file=self.error_stream if error else self.stream,
+                theme=AGENTFLOW_THEME,
+                no_color=not self.capabilities.color,
+                force_terminal=self.capabilities.color,
+                highlight=False,
+                soft_wrap=False,
+            )
+            self._consoles[error] = cached
+        return cached
+
+    @property
+    def glyphs(self) -> Glyphs:
+        """Symbol set matching this terminal's encoding support."""
+        return glyphs_for(self.capabilities.unicode)
 
     @property
     def fullscreen_active(self) -> bool:
         """Whether this invocation currently owns the alternate screen."""
-        return self._screen_context is not None
+        return self._screen_active
 
     def start_fullscreen_session(self) -> bool:
-        """Enter a themed alternate screen for the full command lifetime."""
+        """Run the whole command on a painted alternate screen.
+
+        This switches the terminal buffer directly instead of wrapping the
+        session in a live display: a live display re-homes the cursor before
+        every write, which would overwrite each line the command prints.
+        """
         if self.fullscreen_active or self.quiet or not self.capabilities.animation:
             return False
         console = self._console()
-        screen_context = console.screen(style="on grey3", hide_cursor=False)
+        if not console.is_terminal:
+            return False
+
+        console.set_alt_screen(True)
+        if self.capabilities.color:
+            console.file.write(_FULLSCREEN_PAINT)
+            console.file.flush()
         self._session_console = console
-        self._screen_context = screen_context
-        try:
-            screen_context.__enter__()
-        except Exception:
-            self._session_console = None
-            self._screen_context = None
-            raise
+        self._screen_active = True
         return True
 
     def end_fullscreen_session(self) -> None:
-        """Restore the user's original terminal after a full-screen command."""
-        screen_context = self._screen_context
-        self._screen_context = None
+        """Hold the alternate screen for review, then restore the terminal.
+
+        Releasing an alternate screen discards everything drawn on it, so the
+        session pauses first — otherwise a fast command would erase its own
+        result before the user could read it.
+        """
+        if not self._screen_active:
+            return
+        console = self._session_console
+        self._screen_active = False
         self._session_console = None
-        if screen_context is not None:
-            screen_context.__exit__(None, None, None)
+        if console is None:
+            return
+
+        self._hold_for_review(console)
+        if self.capabilities.color:
+            console.file.write(_FULLSCREEN_RESET)
+            console.file.flush()
+        console.set_alt_screen(False)
+        console.show_cursor(True)
+
+    def _hold_for_review(self, console: Console) -> None:
+        glyphs = self.glyphs
+        console.print()
+        console.print(
+            gradient_rule(max(min(console.width, 100) - 1, 20), glyphs=glyphs, thin=True)
+        )
+        console.print(
+            Text(
+                f" {glyphs.caret} Press Enter to return to your terminal",
+                style="agentflow.muted",
+            )
+        )
+        if not sys.stdin.isatty():
+            return
+        with contextlib.suppress(Exception):
+            sys.stdin.readline()
 
     @property
     def _structured(self) -> bool:
@@ -195,8 +262,22 @@ class OutputFormatter:
         """Render an animated command identity when the terminal supports it."""
         if self.quiet:
             return
-        if not self.capabilities.animation:
+        if self._structured:
+            self._emit_event("section", command, subtitle=subtitle)
+            return
+        if self.capabilities.output_format == OutputFormat.PLAIN:
             self.print_banner(command.title(), subtitle, color=color)
+            return
+        if not self.capabilities.animation:
+            # Still branded, just motionless — reduced motion should not mean
+            # a downgrade in the information the header carries.
+            render_session_header(
+                self._console(),
+                command=command,
+                subtitle=subtitle,
+                glyphs=self.glyphs,
+                version=CLI_VERSION,
+            )
             return
         render_command_intro(
             self._console(),
@@ -205,6 +286,55 @@ class OutputFormatter:
             unicode=self.capabilities.unicode,
             persistent_screen=self.fullscreen_active,
         )
+
+    def timeline(
+        self,
+        title: str | None = None,
+        *,
+        steps: Sequence[tuple[str, str]] = (),
+    ) -> Timeline:
+        """Create a multi-stage progress timeline for the current output mode.
+
+        Declaring ``steps`` up front lets the user see the whole plan the moment
+        work begins, with pending stages dimmed and the running one animated.
+        """
+        if self.quiet:
+            return QuietTimeline(steps)
+        if self._structured:
+            return StructuredTimeline(emit=self._emit_event_data, title=title, steps=steps)
+        if not self.capabilities.animation:
+            return StaticTimeline(
+                glyphs=self.glyphs,
+                emit=self._write_line,
+                title=title,
+                steps=steps,
+            )
+        return LiveTimeline(self._console(), glyphs=self.glyphs, title=title, steps=steps)
+
+    def progress_run(self, title: str, *, total: int) -> ProgressRun:
+        """Create a determinate progress display with a running pass/fail tally."""
+        if self.quiet:
+            return QuietProgressRun(total=total, title=title)
+        if self._structured:
+            return StructuredProgressRun(total=total, title=title, emit=self._emit_event_data)
+        if not self.capabilities.animation:
+            return StaticProgressRun(
+                total=total,
+                title=title,
+                glyphs=self.glyphs,
+                emit=self._write_line,
+            )
+        return LiveProgressRun(self._console(), total=total, title=title, glyphs=self.glyphs)
+
+    def _emit_event_data(self, event: str, message: str, data: dict[str, Any]) -> None:
+        self._emit_event(event, message, **data)
+
+    def _write_line(self, message: str) -> None:
+        """Write one pre-formatted line without interpreting console markup."""
+        if self.capabilities.output_format == OutputFormat.PLAIN:
+            print(message, file=self.stream)
+            return
+        self._console().print(Text(message))
 
     def success(self, message: str, emoji: bool = True) -> None:
         if self.quiet:
@@ -388,25 +518,73 @@ class OutputFormatter:
                 self.print_list(next_steps, title="Next steps", bullet="->")
             return
 
+        console = self._console()
+        rows = list((details or {}).items())
+        steps = list(next_steps or [])
+        total = len(rows) + len(steps)
+
+        if not self.capabilities.animation or not total:
+            console.print(self._completion_panel(title, message, rows, steps, total))
+            return
+
+        # Reveal one row at a time so the result reads as an outcome landing
+        # rather than a wall of text appearing at once.
+        with Live(
+            console=console,
+            auto_refresh=False,
+            transient=False,
+            redirect_stdout=False,
+            redirect_stderr=False,
+        ) as live:
+            for visible in range(total + 1):
+                live.update(
+                    self._completion_panel(title, message, rows, steps, visible),
+                    refresh=True,
+                )
+                time.sleep(0.05)
+
+    def _completion_panel(
+        self,
+        title: str,
+        message: str,
+        rows: list[tuple[str, Any]],
+        steps: list[str],
+        visible: int,
+    ) -> Panel:
+        """Build the completion panel with only its first ``visible`` rows shown."""
+        glyphs = self.glyphs
         body = Text()
-        symbol = "✓" if self.capabilities.unicode else "OK"
-        body.append(f"{symbol} {message}", style="agentflow.success")
-        if details:
-            for key, value in details.items():
-                body.append(f"\n{key:<12}", style="agentflow.muted")
+        body.append(f"{glyphs.check} ", style="agentflow.success")
+        body.append(message, style="agentflow.command")
+
+        shown = 0
+        if rows:
+            label_width = max(len(str(key)) for key, _ in rows) + 2
+            body.append("\n")
+            for key, value in rows:
+                if shown >= visible:
+                    break
+                body.append(f"\n  {key!s:<{label_width}}", style="agentflow.muted")
                 body.append(str(value), style="agentflow.command")
-        if next_steps:
-            body.append("\n\nNext steps", style="bold")
-            arrow = "→" if self.capabilities.unicode else "->"
-            for step in next_steps:
-                body.append(f"\n  {arrow} {step}")
-        self._console().print(
-            Panel(
-                body,
-                title=f"[agentflow.title]{title}[/agentflow.title]",
-                border_style="green",
-                padding=(1, 2),
-            )
+                shown += 1
+
+        if steps and visible > len(rows):
+            body.append("\n\n")
+            body.append("Next", style="bold #a78bfa")
+            for step in steps:
+                if shown >= visible:
+                    break
+                body.append(f"\n  {glyphs.arrow} ", style="agentflow.accent")
+                body.append(step, style="agentflow.command")
+                shown += 1
+
+        return Panel(
+            body,
+            title=gradient_text(f" {title} ", bold=True),
+            title_align="left",
+            box=box.ROUNDED,
+            border_style="#7c3aed",
+            padding=(1, 2),
         )
 
 

--- a/agentflow_cli/cli/core/output.py
+++ b/agentflow_cli/cli/core/output.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any, TextIO
@@ -12,6 +13,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.status import Status
 from rich.table import Table
+from rich.text import Text
 from rich.theme import Theme
 
 from agentflow_cli.cli.capabilities import (
@@ -20,6 +22,7 @@ from agentflow_cli.cli.capabilities import (
     ProgressMode,
     TerminalCapabilities,
 )
+from agentflow_cli.cli.core.animations import render_command_intro
 
 
 _THEME = Theme(
@@ -30,6 +33,9 @@ _THEME = Theme(
         "agentflow.info": "cyan",
         "agentflow.muted": "dim",
         "agentflow.title": "bold magenta",
+        "agentflow.brand": "bold cyan",
+        "agentflow.command": "bold white",
+        "agentflow.progress": "cyan",
     }
 )
 
@@ -146,6 +152,26 @@ class OutputFormatter:
             body += f"\n[agentflow.muted]{subtitle}[/agentflow.muted]"
         self._console().print(Panel.fit(body, border_style=color, padding=(0, 1), width=width))
 
+    def command_header(
+        self,
+        command: str,
+        subtitle: str | None = None,
+        *,
+        color: str = "cyan",
+    ) -> None:
+        """Render an animated command identity when the terminal supports it."""
+        if self.quiet:
+            return
+        if not self.capabilities.animation:
+            self.print_banner(command.title(), subtitle, color=color)
+            return
+        render_command_intro(
+            self._console(),
+            command=command,
+            subtitle=subtitle,
+            unicode=self.capabilities.unicode,
+        )
+
     def success(self, message: str, emoji: bool = True) -> None:
         if self.quiet:
             return
@@ -255,15 +281,99 @@ class OutputFormatter:
         self._console().print(table)
 
     @contextmanager
-    def status(self, message: str) -> Iterator[Status | None]:
+    def status(self, message: str, *, spinner: str = "dots12") -> Iterator[Status | None]:
         """Show an indeterminate status when animation is safe."""
+        if self._structured:
+            self._emit_event("progress_start", message)
+            try:
+                yield None
+            except Exception:
+                self._emit_event("progress_end", message, status="failed")
+                raise
+            else:
+                self._emit_event("progress_end", message, status="completed")
+            return
         if self.quiet or not self.capabilities.animation:
             if not self.quiet and self.capabilities.progress_mode == ProgressMode.PLAIN:
                 self.info(message, emoji=False)
             yield None
             return
-        with self._console().status(message, spinner="dots") as status:
+        with self._console().status(
+            f"[agentflow.progress]{message}[/agentflow.progress]",
+            spinner=spinner,
+            spinner_style="agentflow.brand",
+        ) as status:
             yield status
+
+    @contextmanager
+    def activity(
+        self,
+        message: str,
+        *,
+        done: str | None = None,
+        spinner: str = "dots12",
+    ) -> Iterator[Status | None]:
+        """Animate a bounded task and persist a timed completion state."""
+        started = time.monotonic()
+        try:
+            with self.status(message, spinner=spinner) as status:
+                yield status
+        except Exception:
+            elapsed = time.monotonic() - started
+            self.error(f"{message} failed after {elapsed:.1f}s")
+            raise
+        else:
+            elapsed = time.monotonic() - started
+            self.success(f"{done or message} ({elapsed:.1f}s)")
+
+    def completion_screen(
+        self,
+        title: str,
+        message: str,
+        *,
+        details: dict[str, Any] | None = None,
+        next_steps: list[str] | None = None,
+    ) -> None:
+        """Render a polished final state for a completed workflow."""
+        if self.quiet:
+            return
+        if self._structured:
+            self._emit_event(
+                "completion",
+                message,
+                title=title,
+                details=details or {},
+                next_steps=next_steps or [],
+            )
+            return
+        if self.capabilities.output_format == OutputFormat.PLAIN:
+            self.success(f"{title}: {message}")
+            if details:
+                self.print_key_value_pairs(details)
+            if next_steps:
+                self.print_list(next_steps, title="Next steps", bullet="->")
+            return
+
+        body = Text()
+        symbol = "✓" if self.capabilities.unicode else "OK"
+        body.append(f"{symbol} {message}", style="agentflow.success")
+        if details:
+            for key, value in details.items():
+                body.append(f"\n{key:<12}", style="agentflow.muted")
+                body.append(str(value), style="agentflow.command")
+        if next_steps:
+            body.append("\n\nNext steps", style="bold")
+            arrow = "→" if self.capabilities.unicode else "->"
+            for step in next_steps:
+                body.append(f"\n  {arrow} {step}")
+        self._console().print(
+            Panel(
+                body,
+                title=f"[agentflow.title]{title}[/agentflow.title]",
+                border_style="green",
+                padding=(1, 2),
+            )
+        )
 
 
 output = OutputFormatter()

--- a/agentflow_cli/cli/core/prompts.py
+++ b/agentflow_cli/cli/core/prompts.py
@@ -1,0 +1,204 @@
+"""Guided prompts for the Agentflow CLI.
+
+Every interactive question in the CLI goes through this service rather than
+calling Questionary directly, so that prompts share one theme, one cancellation
+contract, and one non-interactive policy. Commands describe *what* they need to
+ask; how it is rendered, and what happens when there is nobody to answer, is
+decided here.
+
+Cancellation is a normal outcome, not an error: each method returns ``None`` when
+the user presses Ctrl+C or Esc, and callers are expected to treat that as "the
+user changed their mind" and exit cleanly.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+import questionary
+from prompt_toolkit.styles import Style
+
+from agentflow_cli.cli.exceptions import ValidationError
+
+
+# Mirrors cli.core.theme, expressed in prompt_toolkit's style syntax.
+PROMPT_STYLE = Style(
+    [
+        ("qmark", "fg:#22d3ee bold"),
+        ("question", "bold fg:#f8fafc"),
+        ("answer", "fg:#a78bfa bold"),
+        ("pointer", "fg:#22d3ee bold"),
+        ("highlighted", "fg:#22d3ee bold"),
+        ("selected", "fg:#34d399 bold"),
+        ("separator", "fg:#4b5563"),
+        ("instruction", "fg:#64748b"),
+        ("text", "fg:#cbd5f5"),
+        ("disabled", "fg:#4b5563 italic"),
+    ]
+)
+
+MULTI_SELECT_HINT = "space to toggle · a all · i invert · enter to confirm"
+SINGLE_SELECT_HINT = "arrows to move · enter to select"
+
+_UNPROMPTABLE = (
+    "Could not open an interactive prompt on this terminal. "
+    "Pass the value as a command-line flag instead."
+)
+
+
+def prompt_toolkit_available() -> bool:
+    """Whether a full-screen-capable prompt can actually be driven here.
+
+    ``stdin.isatty()`` is not sufficient on Windows: a stdin that reports as a
+    TTY under an MSYS/Cygwin shell still leaves prompt-toolkit unable to attach
+    to a console, and it raises rather than degrading. Probing once up front
+    turns that into an ordinary "cannot prompt" answer.
+    """
+    try:
+        from prompt_toolkit.input.defaults import create_input
+        from prompt_toolkit.output.defaults import create_output
+
+        create_input()
+        create_output()
+    except Exception:
+        return False
+    return True
+
+
+@dataclass(frozen=True)
+class Choice:
+    """One option in a select or multi-select prompt."""
+
+    value: str
+    title: str
+    description: str | None = None
+    checked: bool = False
+    disabled: str | None = None
+
+    def to_questionary(self) -> questionary.Choice:
+        """Render the option, keeping its description visually secondary."""
+        label: list[tuple[str, str]] = [("class:text", self.title)]
+        if self.description:
+            label.append(("class:instruction", f"  {self.description}"))
+        return questionary.Choice(
+            title=label,
+            value=self.value,
+            checked=self.checked,
+            disabled=self.disabled,
+        )
+
+
+class PromptService:
+    """Ask the user questions, or explain why they cannot be asked."""
+
+    def __init__(
+        self,
+        *,
+        interactive: bool | None = None,
+        on_answered: Callable[[], None] | None = None,
+    ) -> None:
+        if interactive is None:
+            interactive = sys.stdin.isatty() and prompt_toolkit_available()
+        self._interactive = interactive
+        # Prompt-toolkit erases from the cursor to the end of the screen, which
+        # reaches past a scrolling region and takes the pinned footer with it.
+        # The owner of that chrome redraws it here once each prompt is done.
+        self._on_answered = on_answered
+
+    @property
+    def interactive(self) -> bool:
+        """Whether there is a user on the other end who can answer."""
+        return self._interactive
+
+    def require_interactive(self, *, field: str, alternatives: str) -> None:
+        """Fail with a recoverable message when a prompt is impossible."""
+        if self._interactive:
+            return
+        raise ValidationError(
+            f"{field} is required and stdin is not interactive. {alternatives}",
+            field=field,
+        )
+
+    def select(
+        self,
+        message: str,
+        choices: Sequence[Choice],
+        *,
+        default: str | None = None,
+        instruction: str | None = SINGLE_SELECT_HINT,
+    ) -> str | None:
+        """Pick exactly one option. Returns None if cancelled."""
+        options = [choice.to_questionary() for choice in choices]
+        default_option = next((o for o in options if o.value == default), None)
+        return self._ask(
+            questionary.select(
+                message,
+                choices=options,
+                default=default_option,
+                instruction=instruction,
+                style=PROMPT_STYLE,
+                qmark="?",
+                use_shortcuts=False,
+                use_indicator=False,
+            )
+        )
+
+    def checkbox(
+        self,
+        message: str,
+        choices: Sequence[Choice],
+        *,
+        instruction: str | None = MULTI_SELECT_HINT,
+        validate: Callable[[list[str]], bool | str] | None = None,
+    ) -> list[str] | None:
+        """Toggle any number of options with space. Returns None if cancelled."""
+        return self._ask(
+            questionary.checkbox(
+                message,
+                choices=[choice.to_questionary() for choice in choices],
+                instruction=instruction,
+                style=PROMPT_STYLE,
+                qmark="?",
+                validate=validate,
+            )
+        )
+
+    def confirm(self, message: str, *, default: bool = False) -> bool | None:
+        """Ask a yes/no question. Returns None if cancelled."""
+        return self._ask(
+            questionary.confirm(message, default=default, style=PROMPT_STYLE, qmark="?")
+        )
+
+    def text(
+        self,
+        message: str,
+        *,
+        default: str = "",
+        validate: Callable[[str], bool | str] | None = None,
+    ) -> str | None:
+        """Ask for a free-text value. Returns None if cancelled."""
+        return self._ask(
+            questionary.text(
+                message,
+                default=default,
+                validate=validate,
+                style=PROMPT_STYLE,
+                qmark="?",
+            )
+        )
+
+    def _ask(self, question: questionary.Question) -> object:
+        """Run one question and restore whatever chrome it may have erased."""
+        try:
+            return question.ask()
+        except ValidationError:
+            raise
+        except Exception as exc:
+            # A terminal that cannot host a prompt is a usage problem with a
+            # clear fix, not an internal error — report it as one.
+            raise ValidationError(_UNPROMPTABLE, field="input") from exc
+        finally:
+            if self._on_answered is not None:
+                self._on_answered()

--- a/agentflow_cli/cli/core/prompts.py
+++ b/agentflow_cli/cli/core/prompts.py
@@ -138,7 +138,7 @@ class PromptService:
         options = [choice.to_questionary() for choice in choices]
         default_option = next((o for o in options if o.value == default), None)
         return self._ask(
-            questionary.select(
+            lambda: questionary.select(
                 message,
                 choices=options,
                 default=default_option,
@@ -160,7 +160,7 @@ class PromptService:
     ) -> list[str] | None:
         """Toggle any number of options with space. Returns None if cancelled."""
         return self._ask(
-            questionary.checkbox(
+            lambda: questionary.checkbox(
                 message,
                 choices=[choice.to_questionary() for choice in choices],
                 instruction=instruction,
@@ -174,7 +174,7 @@ class PromptService:
     def confirm(self, message: str, *, default: bool = False) -> bool | None:
         """Ask a yes/no question. Returns None if cancelled."""
         return self._ask(
-            questionary.confirm(message, default=default, style=PROMPT_STYLE, qmark="?")
+            lambda: questionary.confirm(message, default=default, style=PROMPT_STYLE, qmark="?")
         )
 
     def text(
@@ -186,7 +186,7 @@ class PromptService:
     ) -> str | None:
         """Ask for a free-text value. Returns None if cancelled."""
         return self._ask(
-            questionary.text(
+            lambda: questionary.text(
                 message,
                 default=default,
                 validate=validate,
@@ -195,14 +195,18 @@ class PromptService:
             )
         )
 
-    def _ask(self, question: questionary.Question) -> Any:
-        """Run one question and restore whatever chrome it may have erased.
+    def _ask(self, build: Callable[[], questionary.Question]) -> Any:
+        """Build and run one question, restoring chrome it may have erased.
+
+        The question is constructed inside the guard, not passed in ready-made:
+        questionary builds its prompt-toolkit application eagerly, so a terminal
+        it cannot drive raises during construction rather than during ``ask``.
 
         The answer type depends on the question, so each caller narrows it in
         its own return annotation.
         """
         try:
-            return question.ask()
+            return build().ask()
         except ValidationError:
             raise
         except Exception as exc:

--- a/agentflow_cli/cli/core/prompts.py
+++ b/agentflow_cli/cli/core/prompts.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 import questionary
 from prompt_toolkit.styles import Style
@@ -64,6 +65,10 @@ def prompt_toolkit_available() -> bool:
         create_output()
     except Exception:
         return False
+    return True
+
+
+def _accept_any(_selected: list[str]) -> bool:
     return True
 
 
@@ -161,7 +166,8 @@ class PromptService:
                 instruction=instruction,
                 style=PROMPT_STYLE,
                 qmark="?",
-                validate=validate,
+                # Questionary requires a validator; accept anything by default.
+                validate=validate or _accept_any,
             )
         )
 
@@ -189,8 +195,12 @@ class PromptService:
             )
         )
 
-    def _ask(self, question: questionary.Question) -> object:
-        """Run one question and restore whatever chrome it may have erased."""
+    def _ask(self, question: questionary.Question) -> Any:
+        """Run one question and restore whatever chrome it may have erased.
+
+        The answer type depends on the question, so each caller narrows it in
+        its own return annotation.
+        """
         try:
             return question.ask()
         except ValidationError:

--- a/agentflow_cli/cli/core/screen.py
+++ b/agentflow_cli/cli/core/screen.py
@@ -72,6 +72,8 @@ class AppFrame:
         self._open = False
         self._chrome = False
         self._command = ""
+        self._subtitle: str | None = None
+        self._version: str | None = None
         self._hint = ""
         self._height = 0
         self._width = 0
@@ -123,17 +125,34 @@ class AppFrame:
             return
 
         self._command = command
+        self._subtitle = subtitle
+        self._version = version
         self._hint = hint or "Ctrl+C to cancel"
-        body_top = _HEADER_ROWS + 1
-        body_bottom = self._height - _FOOTER_ROWS
 
         self._write(_CLEAR_SCREEN)
-        self._draw_header(command=command, subtitle=subtitle, version=version)
+        self._draw_header()
         self._draw_footer(self._hint)
         # Confine scrolling to the body, then park the cursor at its top so the
         # first line of output lands directly under the header.
-        self._write(_scroll_region(body_top, body_bottom) + _at(body_top))
+        self._write(_scroll_region(*self._body_bounds()) + _at(_HEADER_ROWS + 1))
         self._chrome = True
+
+    def redraw_chrome(self) -> None:
+        """Repaint the chrome after something else wrote outside the body.
+
+        Prompt-toolkit erases from the cursor to the end of the *screen*, which
+        a scrolling region does not contain — so a prompt takes the footer with
+        it and can clear the region itself. Both are re-asserted here.
+        """
+        if not self._open or not self._chrome:
+            return
+        self._draw_header()
+        self._draw_footer(self._hint)
+        # Setting a scrolling region homes the cursor, so bracket it.
+        self._write(_SAVE_CURSOR + _scroll_region(*self._body_bounds()) + _RESTORE_CURSOR)
+
+    def _body_bounds(self) -> tuple[int, int]:
+        return _HEADER_ROWS + 1, self._height - _FOOTER_ROWS
 
     def close(self, *, hold: bool = True) -> None:
         """Pause on a closing hint, then release the screen and restore the terminal."""
@@ -142,6 +161,7 @@ class AppFrame:
         self._open = False
 
         if self._chrome:
+            self._draw_header()
             self._draw_footer(
                 "Press Enter to close",
                 anchored=True,
@@ -160,13 +180,7 @@ class AppFrame:
     # Chrome rendering
     # ------------------------------------------------------------------
 
-    def _draw_header(
-        self,
-        *,
-        command: str,
-        subtitle: str | None,
-        version: str | None,
-    ) -> None:
+    def _draw_header(self) -> None:
         glyphs = self._glyphs
         width = self._width
 
@@ -174,14 +188,14 @@ class AppFrame:
         identity.append(f"{glyphs.diamond} ", style="agentflow.brand")
         identity.append_text(gradient_text("agentflow", bold=True))
         identity.append(f" {glyphs.caret} ", style="agentflow.muted")
-        identity.append(command, style="agentflow.command")
-        if version:
-            identity.append(" " * max(width - identity.cell_len - len(version) - 1, 1))
-            identity.append(version, style="agentflow.muted")
+        identity.append(self._command, style="agentflow.command")
+        if self._version:
+            identity.append(" " * max(width - identity.cell_len - len(self._version) - 1, 1))
+            identity.append(self._version, style="agentflow.muted")
         _pad(identity, width)
 
         caption = Text(" ", style="agentflow.header")
-        caption.append(subtitle or "", style="agentflow.muted")
+        caption.append(self._subtitle or "", style="agentflow.muted")
         _pad(caption, width)
 
         rows = (

--- a/agentflow_cli/cli/core/screen.py
+++ b/agentflow_cli/cli/core/screen.py
@@ -38,6 +38,8 @@ from agentflow_cli.cli.core.theme import (
 # Background painted across the alternate screen, so the frame reads as its own
 # surface rather than a cleared prompt.
 BACKGROUND = "#0b0b12"
+_BACKGROUND_RGB = tuple(int(BACKGROUND[index : index + 2], 16) for index in (1, 3, 5))
+_PAINT = "\x1b[48;2;{};{};{}m".format(*_BACKGROUND_RGB)
 
 _SAVE_CURSOR = "\x1b7"
 _RESTORE_CURSOR = "\x1b8"
@@ -90,7 +92,7 @@ class AppFrame:
 
     def open(self) -> bool:
         """Enter and paint the alternate screen. Returns False if unsupported."""
-        if self._open or not self._console.is_terminal:
+        if self._open or not self._console.is_terminal or not self._color:
             return False
 
         self._height = self._console.height
@@ -98,8 +100,13 @@ class AppFrame:
         if self._height < _MIN_FRAME_HEIGHT or self._width < _MIN_FRAME_WIDTH:
             return False
 
-        self._console.set_alt_screen(True)
-        self._write(f"\x1b[48;2;11;11;18m{_CLEAR_SCREEN}{_at(1)}")
+        # A legacy console reports itself as a terminal but refuses the alternate
+        # buffer. Bail before painting, or the scrolling region below would be
+        # applied to the user's real scrollback and outlive the process.
+        if not self._console.set_alt_screen(True):
+            return False
+
+        self._write(_PAINT + _CLEAR_SCREEN + _at(1))
         self._open = True
         return True
 
@@ -116,7 +123,7 @@ class AppFrame:
             return
 
         self._command = command
-        self._hint = hint or "Ctrl+C to stop"
+        self._hint = hint or "Ctrl+C to cancel"
         body_top = _HEADER_ROWS + 1
         body_bottom = self._height - _FOOTER_ROWS
 
@@ -207,7 +214,9 @@ class AppFrame:
             status.append(label, style="agentflow.muted")
         _pad(status, width)
 
-        buffer = _SAVE_CURSOR
+        # An anchored footer keeps the cursor parked on it, so there is nothing
+        # to save and restore around the write.
+        buffer = "" if anchored else _SAVE_CURSOR
         buffer += _at(self._height - 1) + self._to_ansi(
             gradient_rule(width, glyphs=glyphs, thin=True, offset=0.6)
         )

--- a/agentflow_cli/cli/core/screen.py
+++ b/agentflow_cli/cli/core/screen.py
@@ -1,0 +1,261 @@
+"""Persistent full-screen application frame for the Agentflow CLI.
+
+The frame claims the terminal's alternate screen for the whole command and keeps
+branded chrome pinned while the command's output scrolls between it:
+
+    row 1..4      header — gradient rule, identity, subtitle, divider
+    row 5..H-2    body   — everything the command prints, scrolling
+    row H-1..H    footer — divider and status/hint bar
+
+Pinning is done with a DEC scrolling region (``CSI top;bottom r``) rather than a
+Rich ``Layout``. That matters: a layout would require every line of output to be
+routed through one renderable, which breaks the moment a command shells out to
+pytest, streams Uvicorn logs, or hands the terminal to a Questionary prompt. A
+scrolling region is enforced by the terminal itself, so ordinary writes — from
+this process or a child — simply scroll inside the body and leave the chrome
+untouched.
+
+Because an alternate screen is discarded when released, ``close()`` pauses on a
+"press Enter" footer first, so a fast command cannot erase its own result.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+from rich.console import Console
+from rich.text import Text
+
+from agentflow_cli.cli.core.theme import (
+    AGENTFLOW_THEME,
+    Glyphs,
+    gradient_rule,
+    gradient_text,
+)
+
+
+# Background painted across the alternate screen, so the frame reads as its own
+# surface rather than a cleared prompt.
+BACKGROUND = "#0b0b12"
+
+_SAVE_CURSOR = "\x1b7"
+_RESTORE_CURSOR = "\x1b8"
+_CLEAR_SCREEN = "\x1b[2J"
+_RESET_REGION = "\x1b[r"
+_RESET_SGR = "\x1b[0m"
+
+_HEADER_ROWS = 4
+_FOOTER_ROWS = 2
+# Below this there is not enough room left for a usable body between the chrome.
+_MIN_FRAME_HEIGHT = 14
+_MIN_FRAME_WIDTH = 50
+
+
+def _at(row: int, column: int = 1) -> str:
+    return f"\x1b[{row};{column}H"
+
+
+def _scroll_region(top: int, bottom: int) -> str:
+    return f"\x1b[{top};{bottom}r"
+
+
+class AppFrame:
+    """Own the alternate screen and keep header/footer chrome pinned to it."""
+
+    def __init__(self, console: Console, *, glyphs: Glyphs, color: bool) -> None:
+        self._console = console
+        self._glyphs = glyphs
+        self._color = color
+        self._open = False
+        self._chrome = False
+        self._command = ""
+        self._hint = ""
+        self._height = 0
+        self._width = 0
+
+    @property
+    def active(self) -> bool:
+        """Whether this frame currently owns the alternate screen."""
+        return self._open
+
+    @property
+    def chrome_installed(self) -> bool:
+        """Whether pinned header/footer chrome is currently drawn."""
+        return self._chrome
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> bool:
+        """Enter and paint the alternate screen. Returns False if unsupported."""
+        if self._open or not self._console.is_terminal:
+            return False
+
+        self._height = self._console.height
+        self._width = self._console.width
+        if self._height < _MIN_FRAME_HEIGHT or self._width < _MIN_FRAME_WIDTH:
+            return False
+
+        self._console.set_alt_screen(True)
+        self._write(f"\x1b[48;2;11;11;18m{_CLEAR_SCREEN}{_at(1)}")
+        self._open = True
+        return True
+
+    def install_chrome(
+        self,
+        *,
+        command: str,
+        subtitle: str | None,
+        version: str | None = None,
+        hint: str | None = None,
+    ) -> None:
+        """Draw the pinned header and footer and confine output to the body."""
+        if not self._open:
+            return
+
+        self._command = command
+        self._hint = hint or "Ctrl+C to stop"
+        body_top = _HEADER_ROWS + 1
+        body_bottom = self._height - _FOOTER_ROWS
+
+        self._write(_CLEAR_SCREEN)
+        self._draw_header(command=command, subtitle=subtitle, version=version)
+        self._draw_footer(self._hint)
+        # Confine scrolling to the body, then park the cursor at its top so the
+        # first line of output lands directly under the header.
+        self._write(_scroll_region(body_top, body_bottom) + _at(body_top))
+        self._chrome = True
+
+    def close(self, *, hold: bool = True) -> None:
+        """Pause on a closing hint, then release the screen and restore the terminal."""
+        if not self._open:
+            return
+        self._open = False
+
+        if self._chrome:
+            self._draw_footer(
+                "Press Enter to close",
+                anchored=True,
+                style="agentflow.brand",
+            )
+            self._chrome = False
+
+        if hold:
+            self._wait_for_enter()
+
+        self._write(_RESET_REGION + _RESET_SGR)
+        self._console.set_alt_screen(False)
+        self._console.show_cursor(True)
+
+    # ------------------------------------------------------------------
+    # Chrome rendering
+    # ------------------------------------------------------------------
+
+    def _draw_header(
+        self,
+        *,
+        command: str,
+        subtitle: str | None,
+        version: str | None,
+    ) -> None:
+        glyphs = self._glyphs
+        width = self._width
+
+        identity = Text(" ", style="agentflow.header")
+        identity.append(f"{glyphs.diamond} ", style="agentflow.brand")
+        identity.append_text(gradient_text("agentflow", bold=True))
+        identity.append(f" {glyphs.caret} ", style="agentflow.muted")
+        identity.append(command, style="agentflow.command")
+        if version:
+            identity.append(" " * max(width - identity.cell_len - len(version) - 1, 1))
+            identity.append(version, style="agentflow.muted")
+        _pad(identity, width)
+
+        caption = Text(" ", style="agentflow.header")
+        caption.append(subtitle or "", style="agentflow.muted")
+        _pad(caption, width)
+
+        rows = (
+            gradient_rule(width, glyphs=glyphs),
+            identity,
+            caption,
+            gradient_rule(width, glyphs=glyphs, thin=True, offset=0.35),
+        )
+        buffer = _SAVE_CURSOR
+        for offset, row in enumerate(rows, start=1):
+            buffer += _at(offset) + self._to_ansi(row)
+        self._write(buffer + _RESTORE_CURSOR)
+
+    def _draw_footer(
+        self,
+        hint: str,
+        *,
+        anchored: bool = False,
+        style: str = "agentflow.muted",
+    ) -> None:
+        glyphs = self._glyphs
+        width = self._width
+
+        status = Text(" ", style="agentflow.header")
+        status.append(f"{glyphs.caret} ", style="agentflow.accent")
+        status.append(hint, style=style)
+        if self._command:
+            label = f"agentflow {self._command}"
+            status.append(" " * max(width - status.cell_len - len(label) - 1, 1))
+            status.append(label, style="agentflow.muted")
+        _pad(status, width)
+
+        buffer = _SAVE_CURSOR
+        buffer += _at(self._height - 1) + self._to_ansi(
+            gradient_rule(width, glyphs=glyphs, thin=True, offset=0.6)
+        )
+        buffer += _at(self._height) + self._to_ansi(status)
+        self._write(buffer + (_at(self._height, width) if anchored else _RESTORE_CURSOR))
+
+    def _to_ansi(self, renderable: Text) -> str:
+        """Render one chrome row to a positioned, self-contained escape string.
+
+        Chrome is written directly rather than printed, because printing would
+        scroll the body region; a standalone console keeps that rendering from
+        disturbing the main console's cursor state.
+        """
+        target = Console(
+            file=io.StringIO(),
+            theme=AGENTFLOW_THEME,
+            force_terminal=True,
+            color_system="truecolor",
+            width=self._width,
+            highlight=False,
+            soft_wrap=True,
+        )
+        with target.capture() as captured:
+            target.print(renderable, end="")
+        return captured.get()
+
+    # ------------------------------------------------------------------
+    # Terminal plumbing
+    # ------------------------------------------------------------------
+
+    def _write(self, payload: str) -> None:
+        if not self._color:
+            # Without color the terminal is not trusted with cursor control either.
+            return
+        self._console.file.write(payload)
+        self._console.file.flush()
+
+    @staticmethod
+    def _wait_for_enter() -> None:
+        if not sys.stdin.isatty():
+            return
+        try:
+            sys.stdin.readline()
+        except (OSError, ValueError, KeyboardInterrupt):
+            return
+
+
+def _pad(text: Text, width: int) -> None:
+    padding = width - text.cell_len
+    if padding > 0:
+        text.append(" " * padding)

--- a/agentflow_cli/cli/core/steps.py
+++ b/agentflow_cli/cli/core/steps.py
@@ -82,6 +82,17 @@ class StepHandle:
             self._step.detail = reason
         self._on_change()
 
+    def fail(self, reason: str = "") -> None:
+        """Mark this stage failed without aborting the rest of the timeline.
+
+        Raising would be the usual way to fail a stage, but some commands want
+        to record one failure and carry on with the remaining work.
+        """
+        self._step.state = StepState.FAILED
+        if reason:
+            self._step.detail = reason
+        self._on_change()
+
 
 class Timeline(Protocol):
     """Shared surface across animated, plain, and structured renderers."""
@@ -159,6 +170,7 @@ class _BaseTimeline:
             self._on_finish(step)
             raise
         step.finished = time.monotonic()
+        # A stage that already reported skip() or fail() keeps that verdict.
         if step.state is StepState.ACTIVE:
             step.state = StepState.DONE
         self._on_finish(step)

--- a/agentflow_cli/cli/core/steps.py
+++ b/agentflow_cli/cli/core/steps.py
@@ -20,6 +20,7 @@ from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import StrEnum
+from types import TracebackType
 from typing import Any, Protocol
 
 from rich.console import Console, Group, RenderableType
@@ -99,7 +100,12 @@ class Timeline(Protocol):
 
     def __enter__(self) -> Timeline: ...
 
-    def __exit__(self, *exc_info: object) -> None: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None: ...
 
     def add(self, key: str, title: str) -> None: ...
 
@@ -111,7 +117,12 @@ class ProgressRun(Protocol):
 
     def __enter__(self) -> ProgressRun: ...
 
-    def __exit__(self, *exc_info: object) -> None: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None: ...
 
     def record(self, label: str, *, status: str, detail: str = "") -> None: ...
 
@@ -219,7 +230,12 @@ class LiveTimeline(_BaseTimeline):
         self._live.__enter__()
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         live = self._live
         self._live = None
         if live is None:
@@ -227,7 +243,7 @@ class LiveTimeline(_BaseTimeline):
         # Paint the resolved state before releasing the region so the final
         # frame is what stays in scrollback.
         live.update(self._render(), refresh=True)
-        live.__exit__(*exc_info)
+        live.__exit__(exc_type, exc, traceback)
         self._console.print()
 
     def _changed(self) -> None:
@@ -325,7 +341,12 @@ class StaticTimeline(_BaseTimeline):
             self._emit(f"{self._glyphs.diamond} {self._title}")
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         return None
 
     def _on_start(self, step: Step) -> None:
@@ -364,7 +385,12 @@ class StructuredTimeline(_BaseTimeline):
         )
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self._emit(
             "timeline_end",
             self._title or "",
@@ -393,7 +419,12 @@ class QuietTimeline(_BaseTimeline):
     def __enter__(self) -> QuietTimeline:
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         return None
 
 
@@ -413,7 +444,12 @@ class _BaseProgressRun:
     def __enter__(self) -> _BaseProgressRun:
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         return None
 
     def record(self, label: str, *, status: str, detail: str = "") -> None:
@@ -481,11 +517,16 @@ class LiveProgressRun(_BaseProgressRun):
         self._task = self._progress.add_task(self.title, total=self.total, tally="")
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         progress = self._progress
         self._progress = None
         if progress is not None:
-            progress.__exit__(*exc_info)
+            progress.__exit__(exc_type, exc, traceback)
             self._console.print()
 
     def _render(self, label: str, status: str, detail: str) -> None:
@@ -555,7 +596,12 @@ class StructuredProgressRun(_BaseProgressRun):
         self._emit("progress_start", self.title, {"total": self.total})
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self._emit("progress_end", self.title, {"total": self.total, **self.tally})
 
     def _render(self, label: str, status: str, detail: str) -> None:

--- a/agentflow_cli/cli/core/steps.py
+++ b/agentflow_cli/cli/core/steps.py
@@ -1,0 +1,563 @@
+"""Live step timelines for multi-stage CLI commands.
+
+A command declares its stages up front, so the user sees the whole plan the
+moment work starts and watches it resolve — rather than a single spinner that
+reveals nothing about what remains. The timeline renders through one Rich
+``Live`` region and is left on screen when the command finishes, so the final
+state stays in scrollback.
+
+Three implementations share one protocol:
+
+``LiveTimeline``     animated, for interactive terminals
+``StaticTimeline``   one line per transition, for pipes, CI, and plain mode
+``StructuredTimeline`` versioned events, for ``--format json``/``jsonl``
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+from rich.console import Console, Group, RenderableType
+from rich.live import Live
+from rich.text import Text
+
+from agentflow_cli.cli.core.theme import Glyphs, sample_ramp
+
+
+_SPINNER_FPS = 12
+_REFRESH_PER_SECOND = 15
+_ELAPSED_COLUMN = 62
+_SECONDS_PER_MINUTE = 60
+
+
+class StepState(StrEnum):
+    """Lifecycle of one stage in a timeline."""
+
+    PENDING = "pending"
+    ACTIVE = "active"
+    DONE = "done"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class Step:
+    """One declared stage and everything needed to render its current state."""
+
+    key: str
+    title: str
+    state: StepState = StepState.PENDING
+    detail: str = ""
+    started: float | None = None
+    finished: float | None = None
+
+    @property
+    def elapsed(self) -> float:
+        if self.started is None:
+            return 0.0
+        return (self.finished or time.monotonic()) - self.started
+
+
+class StepHandle:
+    """Handle a command uses to annotate the stage it is currently running."""
+
+    def __init__(self, step: Step, on_change: Callable[[], None]) -> None:
+        self._step = step
+        self._on_change = on_change
+
+    def detail(self, message: str) -> None:
+        """Replace the sub-line under the active stage."""
+        self._step.detail = message
+        self._on_change()
+
+    def skip(self, reason: str = "") -> None:
+        """Mark this stage as intentionally not performed."""
+        self._step.state = StepState.SKIPPED
+        if reason:
+            self._step.detail = reason
+        self._on_change()
+
+
+class Timeline(Protocol):
+    """Shared surface across animated, plain, and structured renderers."""
+
+    def __enter__(self) -> Timeline: ...
+
+    def __exit__(self, *exc_info: object) -> None: ...
+
+    def add(self, key: str, title: str) -> None: ...
+
+    def step(self, key: str, title: str | None = None) -> Any: ...
+
+
+class ProgressRun(Protocol):
+    """Determinate progress surface shared across output modes."""
+
+    def __enter__(self) -> ProgressRun: ...
+
+    def __exit__(self, *exc_info: object) -> None: ...
+
+    def record(self, label: str, *, status: str, detail: str = "") -> None: ...
+
+
+def format_elapsed(seconds: float) -> str:
+    """Render a duration compactly enough to sit in a fixed-width column."""
+    if seconds < _SECONDS_PER_MINUTE:
+        return f"{seconds:.1f}s"
+    minutes, remainder = divmod(int(seconds), _SECONDS_PER_MINUTE)
+    return f"{minutes}m {remainder:02d}s"
+
+
+class _BaseTimeline:
+    """State machine shared by every timeline renderer."""
+
+    def __init__(self, steps: Sequence[tuple[str, str]] = ()) -> None:
+        self._steps: list[Step] = [Step(key=key, title=title) for key, title in steps]
+        self._index: dict[str, Step] = {step.key: step for step in self._steps}
+
+    def add(self, key: str, title: str) -> None:
+        """Append a stage discovered while the timeline is already running."""
+        if key in self._index:
+            self._index[key].title = title
+            return
+        step = Step(key=key, title=title)
+        self._steps.append(step)
+        self._index[key] = step
+        self._changed()
+
+    def _resolve(self, key: str, title: str | None) -> Step:
+        step = self._index.get(key)
+        if step is None:
+            step = Step(key=key, title=title or key)
+            self._steps.append(step)
+            self._index[key] = step
+        elif title:
+            step.title = title
+        return step
+
+    def _changed(self) -> None:
+        """Hook for renderers that need to repaint on every state change."""
+
+    @contextmanager
+    def _run(self, key: str, title: str | None) -> Iterator[StepHandle]:
+        step = self._resolve(key, title)
+        step.state = StepState.ACTIVE
+        step.started = time.monotonic()
+        step.finished = None
+        self._on_start(step)
+        handle = StepHandle(step, self._changed)
+        try:
+            yield handle
+        except BaseException:
+            step.finished = time.monotonic()
+            step.state = StepState.FAILED
+            self._on_finish(step)
+            raise
+        step.finished = time.monotonic()
+        if step.state is StepState.ACTIVE:
+            step.state = StepState.DONE
+        self._on_finish(step)
+
+    def step(self, key: str, title: str | None = None) -> Any:
+        """Run one stage as a context manager."""
+        return self._run(key, title)
+
+    def _on_start(self, step: Step) -> None:
+        self._changed()
+
+    def _on_finish(self, step: Step) -> None:
+        self._changed()
+
+    @property
+    def failed(self) -> bool:
+        return any(step.state is StepState.FAILED for step in self._steps)
+
+
+class LiveTimeline(_BaseTimeline):
+    """Animated timeline for interactive terminals."""
+
+    def __init__(
+        self,
+        console: Console,
+        *,
+        glyphs: Glyphs,
+        title: str | None = None,
+        steps: Sequence[tuple[str, str]] = (),
+    ) -> None:
+        super().__init__(steps)
+        self._console = console
+        self._glyphs = glyphs
+        self._title = title
+        self._live: Live | None = None
+
+    def __enter__(self) -> LiveTimeline:
+        self._live = Live(
+            self._render(),
+            console=self._console,
+            refresh_per_second=_REFRESH_PER_SECOND,
+            transient=False,
+            redirect_stdout=False,
+            redirect_stderr=False,
+        )
+        self._live.__enter__()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        live = self._live
+        self._live = None
+        if live is None:
+            return
+        # Paint the resolved state before releasing the region so the final
+        # frame is what stays in scrollback.
+        live.update(self._render(), refresh=True)
+        live.__exit__(*exc_info)
+        self._console.print()
+
+    def _changed(self) -> None:
+        if self._live is not None:
+            self._live.update(self._render(), refresh=False)
+
+    def _render(self) -> RenderableType:
+        glyphs = self._glyphs
+        lines: list[RenderableType] = []
+
+        if self._title:
+            heading = Text("  ")
+            heading.append(f"{glyphs.diamond} ", style="agentflow.brand")
+            heading.append(self._title, style="agentflow.command")
+            lines.append(heading)
+
+        total = len(self._steps)
+        for index, step in enumerate(self._steps):
+            last = index == total - 1
+            lines.append(self._render_step(step, last=last))
+            if step.detail:
+                lines.append(self._render_detail(step, last=last))
+        return Group(*lines)
+
+    def _render_step(self, step: Step, *, last: bool) -> Text:
+        glyphs = self._glyphs
+        connector = glyphs.tree_end if last else glyphs.tree_branch
+        line = Text("  ")
+        line.append(f"{connector}{glyphs.thin_rule} ", style="agentflow.rule")
+        line.append_text(self._symbol(step))
+        line.append(" ")
+        line.append(step.title, style=self._title_style(step))
+
+        if step.state in {StepState.ACTIVE, StepState.DONE, StepState.FAILED}:
+            elapsed = format_elapsed(step.elapsed)
+            padding = max(_ELAPSED_COLUMN - line.cell_len, 1)
+            line.append(" " * padding)
+            line.append(elapsed, style="agentflow.elapsed")
+        return line
+
+    def _render_detail(self, step: Step, *, last: bool) -> Text:
+        glyphs = self._glyphs
+        stem = " " if last else glyphs.tree_stem
+        line = Text("  ")
+        line.append(f"{stem}   ", style="agentflow.rule")
+        line.append(step.detail, style="agentflow.muted")
+        return line
+
+    def _symbol(self, step: Step) -> Text:
+        glyphs = self._glyphs
+        if step.state is StepState.DONE:
+            return Text(glyphs.check, style="agentflow.success")
+        if step.state is StepState.FAILED:
+            return Text(glyphs.cross, style="agentflow.error")
+        if step.state is StepState.SKIPPED:
+            return Text(glyphs.skipped, style="agentflow.muted")
+        if step.state is StepState.ACTIVE:
+            frames = glyphs.spinner
+            frame = frames[int(time.monotonic() * _SPINNER_FPS) % len(frames)]
+            # Cycle the brand ramp with the spinner so the active row reads as
+            # the one live element on screen.
+            tint = sample_ramp((time.monotonic() * 0.5) % 1.0)
+            return Text(frame, style=f"bold {tint}")
+        return Text(glyphs.pending, style="agentflow.pending")
+
+    @staticmethod
+    def _title_style(step: Step) -> str:
+        return {
+            StepState.DONE: "agentflow.command",
+            StepState.ACTIVE: "bold #ffffff",
+            StepState.FAILED: "agentflow.error",
+            StepState.SKIPPED: "agentflow.muted",
+            StepState.PENDING: "agentflow.pending",
+        }[step.state]
+
+
+class StaticTimeline(_BaseTimeline):
+    """Line-per-transition timeline for pipes, CI, and plain output."""
+
+    def __init__(
+        self,
+        *,
+        glyphs: Glyphs,
+        emit: Callable[[str], None],
+        title: str | None = None,
+        steps: Sequence[tuple[str, str]] = (),
+    ) -> None:
+        super().__init__(steps)
+        self._glyphs = glyphs
+        self._emit = emit
+        self._title = title
+
+    def __enter__(self) -> StaticTimeline:
+        if self._title:
+            self._emit(f"{self._glyphs.diamond} {self._title}")
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+    def _on_start(self, step: Step) -> None:
+        self._emit(f"{self._glyphs.arrow} {step.title}")
+
+    def _on_finish(self, step: Step) -> None:
+        symbol = {
+            StepState.DONE: self._glyphs.check,
+            StepState.FAILED: self._glyphs.cross,
+            StepState.SKIPPED: self._glyphs.skipped,
+        }.get(step.state, self._glyphs.bullet)
+        suffix = f" ({format_elapsed(step.elapsed)})" if step.state is not StepState.SKIPPED else ""
+        detail = f" — {step.detail}" if step.detail else ""
+        self._emit(f"{symbol} {step.title}{suffix}{detail}")
+
+
+class StructuredTimeline(_BaseTimeline):
+    """Versioned event stream for ``--format json`` and ``--format jsonl``."""
+
+    def __init__(
+        self,
+        *,
+        emit: Callable[[str, str, dict[str, Any]], None],
+        title: str | None = None,
+        steps: Sequence[tuple[str, str]] = (),
+    ) -> None:
+        super().__init__(steps)
+        self._emit = emit
+        self._title = title
+
+    def __enter__(self) -> StructuredTimeline:
+        self._emit(
+            "timeline_start",
+            self._title or "",
+            {"steps": [step.key for step in self._steps]},
+        )
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._emit(
+            "timeline_end",
+            self._title or "",
+            {"status": "failed" if self.failed else "completed"},
+        )
+
+    def _on_start(self, step: Step) -> None:
+        self._emit("step_start", step.title, {"step": step.key})
+
+    def _on_finish(self, step: Step) -> None:
+        self._emit(
+            "step_end",
+            step.title,
+            {
+                "step": step.key,
+                "status": str(step.state),
+                "duration_seconds": round(step.elapsed, 3),
+                "detail": step.detail,
+            },
+        )
+
+
+class QuietTimeline(_BaseTimeline):
+    """No-op timeline used when output is suppressed."""
+
+    def __enter__(self) -> QuietTimeline:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+
+class _BaseProgressRun:
+    """Determinate progress over a known number of items, with a live tally.
+
+    Used where a timeline would not fit: many short, homogeneous units of work
+    whose individual names matter less than how many have passed so far.
+    """
+
+    def __init__(self, *, total: int, title: str) -> None:
+        self.total = total
+        self.title = title
+        self.completed = 0
+        self.tally: dict[str, int] = {"passed": 0, "failed": 0, "error": 0, "skipped": 0}
+
+    def __enter__(self) -> _BaseProgressRun:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+    def record(self, label: str, *, status: str, detail: str = "") -> None:
+        """Register one finished item and repaint."""
+        self.completed += 1
+        if status in self.tally:
+            self.tally[status] += 1
+        self._render(label, status, detail)
+
+    def _render(self, label: str, status: str, detail: str) -> None:
+        """Emit whatever this output mode shows for one finished item."""
+
+
+class LiveProgressRun(_BaseProgressRun):
+    """Animated bar with per-item result lines printed above it."""
+
+    _STATUS_STYLES = {
+        "passed": "agentflow.success",
+        "failed": "agentflow.error",
+        "error": "agentflow.error",
+        "skipped": "agentflow.muted",
+    }
+
+    def __init__(
+        self,
+        console: Console,
+        *,
+        total: int,
+        title: str,
+        glyphs: Glyphs,
+    ) -> None:
+        super().__init__(total=total, title=title)
+        self._console = console
+        self._glyphs = glyphs
+        self._progress: Any | None = None
+        self._task: Any | None = None
+
+    def __enter__(self) -> LiveProgressRun:
+        from rich.progress import (
+            BarColumn,
+            Progress,
+            SpinnerColumn,
+            TextColumn,
+            TimeElapsedColumn,
+        )
+
+        self._progress = Progress(
+            SpinnerColumn(spinner_name="dots12", style="agentflow.brand"),
+            TextColumn("[agentflow.command]{task.description}"),
+            BarColumn(
+                bar_width=None,
+                style="#242438",
+                complete_style="#22d3ee",
+                finished_style="#34d399",
+            ),
+            TextColumn("[agentflow.muted]{task.completed}/{task.total}"),
+            TextColumn("{task.fields[tally]}"),
+            TimeElapsedColumn(),
+            console=self._console,
+            transient=False,
+            redirect_stdout=False,
+            redirect_stderr=False,
+        )
+        self._progress.__enter__()
+        self._task = self._progress.add_task(self.title, total=self.total, tally="")
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        progress = self._progress
+        self._progress = None
+        if progress is not None:
+            progress.__exit__(*exc_info)
+            self._console.print()
+
+    def _render(self, label: str, status: str, detail: str) -> None:
+        glyphs = self._glyphs
+        symbol = glyphs.check if status == "passed" else glyphs.cross
+        style = self._STATUS_STYLES.get(status, "agentflow.muted")
+
+        line = Text(f"  {symbol} ", style=style)
+        line.append(label, style="agentflow.command")
+        if detail:
+            line.append(f"  {detail}", style="agentflow.muted")
+        # Printed through the progress object so Rich scrolls it above the bar
+        # instead of fighting the bar for the same terminal row.
+        if self._progress is not None and self._task is not None:
+            self._progress.console.print(line)
+            self._progress.update(self._task, completed=self.completed, tally=self._tally_text())
+
+    def _tally_text(self) -> Text:
+        glyphs = self._glyphs
+        text = Text()
+        text.append(f"{glyphs.check}{self.tally['passed']}", style="agentflow.success")
+        failures = self.tally["failed"] + self.tally["error"]
+        if failures:
+            text.append(f" {glyphs.cross}{failures}", style="agentflow.error")
+        return text
+
+
+class StaticProgressRun(_BaseProgressRun):
+    """One line per finished item, for pipes, CI, and plain output."""
+
+    def __init__(
+        self,
+        *,
+        total: int,
+        title: str,
+        glyphs: Glyphs,
+        emit: Callable[[str], None],
+    ) -> None:
+        super().__init__(total=total, title=title)
+        self._glyphs = glyphs
+        self._emit = emit
+
+    def __enter__(self) -> StaticProgressRun:
+        self._emit(f"{self._glyphs.diamond} {self.title} ({self.total})")
+        return self
+
+    def _render(self, label: str, status: str, detail: str) -> None:
+        symbol = self._glyphs.check if status == "passed" else self._glyphs.cross
+        suffix = f"  {detail}" if detail else ""
+        self._emit(f"[{self.completed:>3}/{self.total}] {symbol} {label}  {status.upper()}{suffix}")
+
+
+class StructuredProgressRun(_BaseProgressRun):
+    """Versioned per-item events for ``--format json`` and ``--format jsonl``."""
+
+    def __init__(
+        self,
+        *,
+        total: int,
+        title: str,
+        emit: Callable[[str, str, dict[str, Any]], None],
+    ) -> None:
+        super().__init__(total=total, title=title)
+        self._emit = emit
+
+    def __enter__(self) -> StructuredProgressRun:
+        self._emit("progress_start", self.title, {"total": self.total})
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._emit("progress_end", self.title, {"total": self.total, **self.tally})
+
+    def _render(self, label: str, status: str, detail: str) -> None:
+        self._emit(
+            "progress",
+            label,
+            {
+                "status": status,
+                "detail": detail,
+                "completed": self.completed,
+                "total": self.total,
+            },
+        )
+
+
+class QuietProgressRun(_BaseProgressRun):
+    """No-op progress used when output is suppressed."""

--- a/agentflow_cli/cli/core/theme.py
+++ b/agentflow_cli/cli/core/theme.py
@@ -1,0 +1,211 @@
+"""Brand palette, glyph sets, and gradient helpers for the Agentflow terminal UI.
+
+Everything visual in the CLI resolves through this module so a single palette
+change restyles intros, timelines, tables, and completion screens at once.
+Glyphs are separated from color because a terminal can support one without the
+other: ASCII fallbacks keep the layout identical when Unicode is unavailable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rich.text import Text
+from rich.theme import Theme
+
+
+# Cyan -> violet -> magenta. Sampled continuously, so stop count only affects
+# how much hue travel each segment carries, never the smoothness of the result.
+BRAND_RAMP: tuple[str, ...] = (
+    "#22d3ee",
+    "#38bdf8",
+    "#60a5fa",
+    "#818cf8",
+    "#a78bfa",
+    "#c084fc",
+    "#e879f9",
+    "#f472b6",
+)
+
+# Used for rows that are done, running, and not started, respectively.
+STATE_RAMP: tuple[str, ...] = ("#34d399", "#22d3ee", "#4b5563")
+
+AGENTFLOW_THEME = Theme(
+    {
+        "agentflow.success": "bold #34d399",
+        "agentflow.error": "bold #f87171",
+        "agentflow.warning": "bold #fbbf24",
+        "agentflow.info": "#38bdf8",
+        "agentflow.muted": "dim #94a3b8",
+        "agentflow.title": "bold #c084fc",
+        "agentflow.brand": "bold #22d3ee",
+        "agentflow.command": "bold #f8fafc",
+        "agentflow.progress": "#38bdf8",
+        "agentflow.accent": "#a78bfa",
+        "agentflow.pending": "#4b5563",
+        "agentflow.rule": "#312e81",
+        "agentflow.chip": "bold #f8fafc on #4c1d95",
+        "agentflow.header": "on #16161f",
+        "agentflow.elapsed": "dim #64748b",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Glyphs:
+    """Symbol set for one invocation, chosen by terminal encoding support."""
+
+    check: str
+    cross: str
+    warn: str
+    info: str
+    bullet: str
+    arrow: str
+    pending: str
+    active: str
+    skipped: str
+    rule: str
+    thin_rule: str
+    node: str
+    diamond: str
+    caret: str
+    block: str
+    cursor: str
+    tree_stem: str
+    tree_branch: str
+    tree_end: str
+    spinner: tuple[str, ...]
+    shades: tuple[str, ...]
+
+
+UNICODE_GLYPHS = Glyphs(
+    check="✓",
+    cross="✗",
+    warn="▲",
+    info="•",
+    bullet="•",
+    arrow="→",
+    pending="○",
+    active="◆",
+    skipped="⊘",
+    rule="━",
+    thin_rule="─",
+    node="◉",
+    diamond="◆",
+    caret="▸",
+    block="█",
+    cursor="▌",
+    tree_stem="┃",
+    tree_branch="┣",
+    tree_end="┗",
+    spinner=("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"),
+    shades=(" ", "░", "▒", "▓", "█"),
+)
+
+ASCII_GLYPHS = Glyphs(
+    check="OK",
+    cross="X",
+    warn="!",
+    info="*",
+    bullet="*",
+    arrow="->",
+    pending="o",
+    active="*",
+    skipped="-",
+    rule="=",
+    thin_rule="-",
+    node="O",
+    diamond="*",
+    caret=">",
+    block="#",
+    cursor="|",
+    tree_stem="|",
+    tree_branch="+",
+    tree_end="\\",
+    spinner=("|", "/", "-", "\\"),
+    shades=(" ", ".", ":", "+", "#"),
+)
+
+
+def glyphs_for(unicode: bool) -> Glyphs:
+    """Return the glyph set matching the terminal's encoding support."""
+    return UNICODE_GLYPHS if unicode else ASCII_GLYPHS
+
+
+def _hex_to_rgb(value: str) -> tuple[int, int, int]:
+    raw = value.lstrip("#")
+    return int(raw[0:2], 16), int(raw[2:4], 16), int(raw[4:6], 16)
+
+
+def _rgb_to_hex(rgb: tuple[int, int, int]) -> str:
+    return "#{:02x}{:02x}{:02x}".format(*rgb)
+
+
+def sample_ramp(position: float, ramp: tuple[str, ...] = BRAND_RAMP) -> str:
+    """Sample a continuous color from ``ramp`` at ``position`` in ``[0, 1]``.
+
+    Interpolating between stops rather than snapping to the nearest one is what
+    keeps a wide gradient bar from showing visible banding.
+    """
+    if not ramp:
+        return "#ffffff"
+    if len(ramp) == 1:
+        return ramp[0]
+
+    clamped = min(max(position, 0.0), 1.0)
+    scaled = clamped * (len(ramp) - 1)
+    index = int(scaled)
+    if index >= len(ramp) - 1:
+        return ramp[-1]
+
+    blend = scaled - index
+    start = _hex_to_rgb(ramp[index])
+    end = _hex_to_rgb(ramp[index + 1])
+    return _rgb_to_hex(
+        (
+            round(start[0] + (end[0] - start[0]) * blend),
+            round(start[1] + (end[1] - start[1]) * blend),
+            round(start[2] + (end[2] - start[2]) * blend),
+        )
+    )
+
+
+def dim_hex(value: str, factor: float) -> str:
+    """Scale a hex color toward black, for pending or background elements."""
+    red, green, blue = _hex_to_rgb(value)
+    scale = min(max(factor, 0.0), 1.0)
+    return _rgb_to_hex((round(red * scale), round(green * scale), round(blue * scale)))
+
+
+def gradient_text(
+    value: str,
+    *,
+    ramp: tuple[str, ...] = BRAND_RAMP,
+    bold: bool = False,
+    offset: float = 0.0,
+    span: float = 1.0,
+) -> Text:
+    """Paint ``value`` with a per-character sweep through ``ramp``.
+
+    ``offset`` shifts the sweep so successive frames can animate a shimmer
+    without rebuilding the palette.
+    """
+    text = Text()
+    length = max(len(value), 1)
+    weight = "bold " if bold else ""
+    for index, character in enumerate(value):
+        position = (offset + (index / length) * span) % 1.0
+        text.append(character, style=f"{weight}{sample_ramp(position, ramp)}")
+    return text
+
+
+def gradient_rule(
+    width: int,
+    *,
+    glyphs: Glyphs,
+    thin: bool = False,
+    offset: float = 0.0,
+) -> Text:
+    """Build a full-width gradient rule used to frame branded sections."""
+    character = glyphs.thin_rule if thin else glyphs.rule
+    return gradient_text(character * max(width, 1), offset=offset)

--- a/agentflow_cli/cli/exceptions.py
+++ b/agentflow_cli/cli/exceptions.py
@@ -1,10 +1,22 @@
 """Custom exceptions for the Agentflow CLI."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
+
 
 class AgentflowCLIError(Exception):
     """Base exception for all Agentflow CLI errors."""
 
-    def __init__(self, message: str, exit_code: int = 1) -> None:
+    def __init__(
+        self,
+        message: str,
+        exit_code: int = 1,
+        *,
+        code: str = "AF-CMD-001",
+        hints: Sequence[str] = (),
+        docs_url: str | None = None,
+    ) -> None:
         """Initialize the exception with a message and exit code.
 
         Args:
@@ -14,6 +26,9 @@ class AgentflowCLIError(Exception):
         super().__init__(message)
         self.message = message
         self.exit_code = exit_code
+        self.code = code
+        self.hints = tuple(hints)
+        self.docs_url = docs_url
 
 
 class ConfigurationError(AgentflowCLIError):
@@ -26,7 +41,7 @@ class ConfigurationError(AgentflowCLIError):
             message: Error message
             config_path: Path to the problematic config file
         """
-        super().__init__(message, exit_code=2)
+        super().__init__(message, exit_code=2, code="AF-CONFIG-001")
         self.config_path = config_path
 
 
@@ -40,7 +55,7 @@ class ValidationError(AgentflowCLIError):
             message: Error message
             field: Name of the field that failed validation
         """
-        super().__init__(message, exit_code=3)
+        super().__init__(message, exit_code=3, code="AF-INPUT-001")
         self.field = field
 
 
@@ -54,7 +69,7 @@ class FileOperationError(AgentflowCLIError):
             message: Error message
             file_path: Path to the problematic file
         """
-        super().__init__(message, exit_code=1)
+        super().__init__(message, exit_code=1, code="AF-FILE-001")
         self.file_path = file_path
 
 
@@ -68,7 +83,7 @@ class TemplateError(AgentflowCLIError):
             message: Error message
             template_name: Name of the problematic template
         """
-        super().__init__(message, exit_code=1)
+        super().__init__(message, exit_code=1, code="AF-TEMPLATE-001")
         self.template_name = template_name
 
 
@@ -83,7 +98,7 @@ class ServerError(AgentflowCLIError):
             host: Server host
             port: Server port
         """
-        super().__init__(message, exit_code=1)
+        super().__init__(message, exit_code=1, code="AF-SERVER-001")
         self.host = host
         self.port = port
 
@@ -98,5 +113,17 @@ class DockerError(AgentflowCLIError):
             message: Error message
             dockerfile_path: Path to the Dockerfile
         """
-        super().__init__(message, exit_code=1)
+        super().__init__(message, exit_code=1, code="AF-DOCKER-001")
         self.dockerfile_path = dockerfile_path
+
+
+class DependencyError(AgentflowCLIError):
+    """Raised when an optional feature dependency is missing or incompatible."""
+
+    def __init__(self, message: str, *, hints: Sequence[str] = ()) -> None:
+        super().__init__(
+            message,
+            exit_code=4,
+            code="AF-DEPS-001",
+            hints=hints,
+        )

--- a/agentflow_cli/cli/logger.py
+++ b/agentflow_cli/cli/logger.py
@@ -1,4 +1,6 @@
-"""Logging configuration for the Agentflow CLI."""
+"""Centralized logging configuration for the Agentflow CLI."""
+
+from __future__ import annotations
 
 import logging
 import sys
@@ -7,11 +9,13 @@ from typing import TextIO
 from .constants import LOG_DATE_FORMAT, LOG_FORMAT
 
 
+_LOGGER_NAME = "agentflowcli"
+
+
 class CLILoggerMixin:
-    """Mixin to add logging capabilities to CLI commands."""
+    """Mixin that obtains a child of the invocation-wide CLI logger."""
 
     def __init__(self, *args, **kwargs) -> None:
-        """Initialize the logger mixin."""
         super().__init__(*args, **kwargs)
         self.logger = get_logger(self.__class__.__name__)
 
@@ -21,40 +25,30 @@ def get_logger(
     level: int = logging.INFO,
     stream: TextIO | None = None,
 ) -> logging.Logger:
-    """Get a configured logger for the CLI.
+    """Return a child logger governed by the shared root configuration.
 
-    Args:
-        name: Logger name
-        level: Logging level
-        stream: Output stream (defaults to stderr)
-
-    Returns:
-        Configured logger instance
+    A custom stream is intended for isolated tests and receives a local handler.
+    Normal command loggers propagate to exactly one root handler so verbosity
+    changes apply consistently and messages cannot be duplicated.
     """
-    logger = logging.getLogger(f"agentflowcli.{name}")
+    logger = logging.getLogger(f"{_LOGGER_NAME}.{name}")
 
-    # Avoid adding multiple handlers if logger already exists
-    if logger.handlers:
+    if stream is not None:
+        logger.handlers.clear()
+        logger.setLevel(level)
+        handler = logging.StreamHandler(stream)
+        handler.setLevel(level)
+        handler.setFormatter(_formatter())
+        logger.addHandler(handler)
+        logger.propagate = False
         return logger
 
-    logger.setLevel(level)
-
-    # Create console handler
-    handler = logging.StreamHandler(stream or sys.stderr)
-    handler.setLevel(level)
-
-    # Create formatter
-    formatter = logging.Formatter(
-        fmt=LOG_FORMAT,
-        datefmt=LOG_DATE_FORMAT,
-    )
-    handler.setFormatter(formatter)
-
-    logger.addHandler(handler)
-
-    # Prevent propagation to root logger
-    logger.propagate = False
-
+    root_logger = logging.getLogger(_LOGGER_NAME)
+    if not root_logger.handlers:
+        setup_cli_logging(level=level)
+    logger.handlers.clear()
+    logger.setLevel(logging.NOTSET)
+    logger.propagate = True
     return logger
 
 
@@ -63,47 +57,28 @@ def setup_cli_logging(
     quiet: bool = False,
     verbose: bool = False,
 ) -> None:
-    """Setup logging for the entire CLI application.
-
-    Args:
-        level: Base logging level
-        quiet: Suppress all output except errors
-        verbose: Enable verbose output
-    """
+    """Configure the one shared CLI logging handler."""
     if quiet:
         level = logging.ERROR
     elif verbose:
         level = logging.DEBUG
 
-    # Configure root logger for the CLI
-    root_logger = logging.getLogger("agentflowcli")
+    root_logger = logging.getLogger(_LOGGER_NAME)
     root_logger.setLevel(level)
+    root_logger.handlers.clear()
 
-    # Remove existing handlers
-    for handler in root_logger.handlers[:]:
-        root_logger.removeHandler(handler)
-
-    # Add console handler
     handler = logging.StreamHandler(sys.stderr)
     handler.setLevel(level)
-
-    formatter = logging.Formatter(
-        fmt=LOG_FORMAT,
-        datefmt=LOG_DATE_FORMAT,
-    )
-    handler.setFormatter(formatter)
-
+    handler.setFormatter(_formatter())
     root_logger.addHandler(handler)
     root_logger.propagate = False
 
 
 def create_debug_logger(name: str) -> logging.Logger:
-    """Create a debug-level logger for development.
+    """Return a child logger after enabling debug output globally."""
+    setup_cli_logging(level=logging.DEBUG)
+    return get_logger(name)
 
-    Args:
-        name: Logger name
 
-    Returns:
-        Debug logger instance
-    """
-    return get_logger(name, level=logging.DEBUG)
+def _formatter() -> logging.Formatter:
+    return logging.Formatter(fmt=LOG_FORMAT, datefmt=LOG_DATE_FORMAT)

--- a/agentflow_cli/cli/main.py
+++ b/agentflow_cli/cli/main.py
@@ -508,6 +508,61 @@ def play(
         sys.exit(handle_exception(e))
 
 
+@app.command()
+def dev(
+    config: str = typer.Option(
+        DEFAULT_CONFIG_FILE,
+        "--config",
+        "-c",
+        help="Path to the project configuration file.",
+    ),
+    host: str = typer.Option(
+        DEFAULT_HOST,
+        "--host",
+        "-H",
+        help="Host interface for the local development server.",
+    ),
+    port: int = typer.Option(
+        DEFAULT_PORT,
+        "--port",
+        "-p",
+        help="Port for the local development server.",
+    ),
+    reload: bool = typer.Option(
+        True,
+        "--reload/--no-reload",
+        help="Reload the server when project files change.",
+    ),
+    open_playground: bool = typer.Option(
+        True,
+        "--open/--no-open",
+        help="Open the hosted playground when the API is ready.",
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging."),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress all output except errors.",
+    ),
+) -> None:
+    """Start the local Agentflow development server."""
+    _configure_command(verbose=verbose, quiet=quiet)
+
+    try:
+        command = APICommand(output)
+        exit_code = command.execute(
+            config=config,
+            host=host,
+            port=port,
+            reload=reload,
+            open_playground=open_playground,
+        )
+        sys.exit(exit_code)
+    except Exception as e:
+        sys.exit(handle_exception(e))
+
+
 @app.command(
     epilog=(
         "Examples:\n"

--- a/agentflow_cli/cli/main.py
+++ b/agentflow_cli/cli/main.py
@@ -125,6 +125,12 @@ def root(  # noqa: PLR0913
         help="Progress mode: auto, tty, plain, json, or quiet.",
         rich_help_panel="Global output",
     ),
+    animation: bool | None = typer.Option(
+        None,
+        "--animation/--no-animation",
+        help="Enable or disable decorative command animation.",
+        rich_help_panel="Global output",
+    ),
     cwd: Path | None = typer.Option(
         None,
         "--cwd",
@@ -188,6 +194,12 @@ def root(  # noqa: PLR0913
             raise typer.BadParameter("--json cannot be combined with a different --format.")
         if no_color and color not in {None, ColorMode.NEVER}:
             raise typer.BadParameter("--no-color cannot be combined with a different --color.")
+        if animation is not None and progress is not None:
+            expected = ProgressMode.TTY if animation else ProgressMode.PLAIN
+            if progress != expected:
+                raise typer.BadParameter(
+                    "--animation/--no-animation conflicts with the selected --progress mode."
+                )
         resolved_format = output_format or OutputFormat(
             preferences.get("output.format", OutputFormat.HUMAN)
         )
@@ -199,6 +211,8 @@ def root(  # noqa: PLR0913
             resolved_format = OutputFormat.JSON
         if no_color:
             resolved_color = ColorMode.NEVER
+        if animation is not None:
+            resolved_progress = ProgressMode.TTY if animation else ProgressMode.PLAIN
     except (ConfigurationError, ValueError) as exc:
         if ctx.invoked_subcommand != "config":
             raise typer.BadParameter(

--- a/agentflow_cli/cli/main.py
+++ b/agentflow_cli/cli/main.py
@@ -43,7 +43,7 @@ def _lazy_command(module_name: str, class_name: str) -> type:
                 raise DependencyError(
                     f"The {feature} command could not load its required dependencies: {exc}",
                     hints=(
-                        "Run `agentflow doctor` to inspect installed package compatibility.",
+                        "Run `agentflow audit` to inspect installed package compatibility.",
                         "Upgrade with `python -m pip install --upgrade "
                         '"10xscale-agentflow>=0.9,<2"`.',
                     ),
@@ -57,10 +57,10 @@ def _lazy_command(module_name: str, class_name: str) -> type:
 
 
 APICommand = _lazy_command("agentflow_cli.cli.commands.api", "APICommand")
+AuditCommand = _lazy_command("agentflow_cli.cli.commands.audit", "AuditCommand")
 BuildCommand = _lazy_command("agentflow_cli.cli.commands.build", "BuildCommand")
 DemoCommand = _lazy_command("agentflow_cli.cli.commands.demo", "DemoCommand")
 EvalCommand = _lazy_command("agentflow_cli.cli.commands.eval", "EvalCommand")
-DoctorCommand = _lazy_command("agentflow_cli.cli.commands.doctor", "DoctorCommand")
 InitCommand = _lazy_command("agentflow_cli.cli.commands.init", "InitCommand")
 SkillsCommand = _lazy_command("agentflow_cli.cli.commands.skills", "SkillsCommand")
 TestCommand = _lazy_command("agentflow_cli.cli.commands.test", "TestCommand")
@@ -508,36 +508,15 @@ def play(
         sys.exit(handle_exception(e))
 
 
-@app.command()
-def dev(
-    config: str = typer.Option(
-        DEFAULT_CONFIG_FILE,
-        "--config",
-        "-c",
-        help="Path to the project configuration file.",
+@app.command(
+    epilog=(
+        "Examples:\n"
+        "  agentflow audit\n"
+        "  agentflow --format json audit\n"
+        "  agentflow --no-animation audit"
     ),
-    host: str = typer.Option(
-        DEFAULT_HOST,
-        "--host",
-        "-H",
-        help="Host interface for the local development server.",
-    ),
-    port: int = typer.Option(
-        DEFAULT_PORT,
-        "--port",
-        "-p",
-        help="Port for the local development server.",
-    ),
-    reload: bool = typer.Option(
-        True,
-        "--reload/--no-reload",
-        help="Reload the server when project files change.",
-    ),
-    open_playground: bool = typer.Option(
-        True,
-        "--open/--no-open",
-        help="Open the hosted playground when the API is ready.",
-    ),
+)
+def audit(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging."),
     quiet: bool = typer.Option(
         False,
@@ -546,37 +525,21 @@ def dev(
         help="Suppress all output except errors.",
     ),
 ) -> None:
-    """Start the local Agentflow development server."""
-    _configure_command(verbose=verbose, quiet=quiet)
+    """Audit package compatibility and the current project environment.
 
-    try:
-        command = APICommand(output)
-        exit_code = command.execute(
-            config=config,
-            host=host,
-            port=port,
-            reload=reload,
-            open_playground=open_playground,
-        )
-        sys.exit(exit_code)
-    except Exception as e:
-        sys.exit(handle_exception(e))
+    Runs six read-only checks and prints them as a table: the Python
+    interpreter, the installed CLI and core packages, whether the core exposes
+    the evaluation API this CLI expects, whether `agentflow.json` is present
+    and declares a valid `agent` key, and whether the default port is free.
 
-
-@app.command()
-def doctor(
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging."),
-    quiet: bool = typer.Option(
-        False,
-        "--quiet",
-        "-q",
-        help="Suppress all output except errors.",
-    ),
-) -> None:
-    """Diagnose package compatibility and the current project environment."""
+    Nothing is written or changed, so it is safe to run anywhere. Exits 1 if
+    any check fails and 0 otherwise, which makes it usable as a CI gate;
+    warnings (no project config, port already bound) are reported without
+    failing the run.
+    """
     _configure_command(verbose=verbose, quiet=quiet)
     try:
-        sys.exit(DoctorCommand(output).execute())
+        sys.exit(AuditCommand(output).execute())
     except Exception as e:
         sys.exit(handle_exception(e))
 

--- a/agentflow_cli/cli/main.py
+++ b/agentflow_cli/cli/main.py
@@ -1,43 +1,343 @@
-"""Professional Agentflow CLI main entry point."""
+"""Agentflow CLI entry point and lightweight command registry."""
 
+import importlib
+import json
+import os
 import sys
+from pathlib import Path
+from typing import Any
 
 import typer
-from dotenv import load_dotenv
 
-from agentflow_cli.cli.commands.api import APICommand
-from agentflow_cli.cli.commands.build import BuildCommand
-from agentflow_cli.cli.commands.eval import EvalCommand
-from agentflow_cli.cli.commands.init import InitCommand
-from agentflow_cli.cli.commands.skills import SkillsCommand
-from agentflow_cli.cli.commands.test import TestCommand
-from agentflow_cli.cli.commands.version import VersionCommand
+from agentflow_cli.cli.capabilities import ColorMode, OutputFormat, ProgressMode
 from agentflow_cli.cli.constants import (
+    CLI_VERSION,
     DEFAULT_CONFIG_FILE,
     DEFAULT_HOST,
     DEFAULT_PORT,
 )
+from agentflow_cli.cli.context import CLIContext
 from agentflow_cli.cli.core.output import OutputFormatter
-from agentflow_cli.cli.exceptions import AgentflowCLIError
+from agentflow_cli.cli.exceptions import AgentflowCLIError, ConfigurationError, DependencyError
 from agentflow_cli.cli.logger import setup_cli_logging
+from agentflow_cli.cli.user_config import UserConfigStore, parse_config_value
 
 
-# Load environment variables
-load_dotenv()
+def _lazy_command(module_name: str, class_name: str) -> type:
+    """Create a compatibility-preserving lazy command adapter.
+
+    Only the selected command's implementation and heavy dependencies are imported.
+    Keeping these class-shaped adapters also preserves the public monkeypatch surface
+    used by downstream tests and integrations.
+    """
+
+    class LazyCommand:
+        def __init__(self, output: OutputFormatter | None = None) -> None:
+            self.output = output
+
+        def execute(self, *args: Any, **kwargs: Any) -> int:
+            try:
+                module = importlib.import_module(module_name)
+            except ImportError as exc:
+                feature = class_name.removesuffix("Command").lower()
+                raise DependencyError(
+                    f"The {feature} command could not load its required dependencies: {exc}",
+                    hints=(
+                        "Run `agentflow doctor` to inspect installed package compatibility.",
+                        "Upgrade with `python -m pip install --upgrade "
+                        '"10xscale-agentflow>=0.9,<2"`.',
+                    ),
+                ) from exc
+            implementation = getattr(module, class_name)
+            return implementation(self.output).execute(*args, **kwargs)
+
+    LazyCommand.__name__ = class_name
+    LazyCommand.__qualname__ = class_name
+    return LazyCommand
+
+
+APICommand = _lazy_command("agentflow_cli.cli.commands.api", "APICommand")
+BuildCommand = _lazy_command("agentflow_cli.cli.commands.build", "BuildCommand")
+EvalCommand = _lazy_command("agentflow_cli.cli.commands.eval", "EvalCommand")
+DoctorCommand = _lazy_command("agentflow_cli.cli.commands.doctor", "DoctorCommand")
+InitCommand = _lazy_command("agentflow_cli.cli.commands.init", "InitCommand")
+SkillsCommand = _lazy_command("agentflow_cli.cli.commands.skills", "SkillsCommand")
+TestCommand = _lazy_command("agentflow_cli.cli.commands.test", "TestCommand")
+VersionCommand = _lazy_command("agentflow_cli.cli.commands.version", "VersionCommand")
 
 # Create the main Typer app
 app = typer.Typer(
     name="agentflow",
-    help=(
-        "Agentflow API CLI - Professional tool for managing Agentflow API "
-        "servers and configurations"
+    help="Build, run, test, and evaluate production-ready Agentflow agents.",
+    epilog=(
+        "Examples:\n"
+        "  agentflow init\n"
+        "  agentflow dev\n"
+        "  agentflow test --coverage\n"
+        "  agentflow eval --parallel"
     ),
     context_settings={"help_option_names": ["-h", "--help"]},
     no_args_is_help=True,
+    rich_markup_mode="rich",
+    pretty_exceptions_enable=False,
 )
+config_app = typer.Typer(
+    name="config",
+    help="Inspect and manage user-level Agentflow CLI preferences.",
+    no_args_is_help=True,
+)
+app.add_typer(config_app, name="config", rich_help_panel="Manage")
 
 # Initialize global output formatter
 output = OutputFormatter()
+
+
+@app.callback(invoke_without_command=True)
+def root(  # noqa: PLR0913
+    ctx: typer.Context,
+    output_format: OutputFormat | None = typer.Option(
+        None,
+        "--format",
+        help="Output format: human, plain, json, or jsonl.",
+        rich_help_panel="Global output",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit versioned JSON output; shorthand for --format json.",
+        rich_help_panel="Global output",
+    ),
+    color: ColorMode | None = typer.Option(
+        None,
+        "--color",
+        help="Color policy: auto, always, or never.",
+        rich_help_panel="Global output",
+    ),
+    no_color: bool = typer.Option(
+        False,
+        "--no-color",
+        help="Disable ANSI color; shorthand for --color never.",
+        rich_help_panel="Global output",
+    ),
+    progress: ProgressMode | None = typer.Option(
+        None,
+        "--progress",
+        help="Progress mode: auto, tty, plain, json, or quiet.",
+        rich_help_panel="Global output",
+    ),
+    cwd: Path | None = typer.Option(
+        None,
+        "--cwd",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        resolve_path=True,
+        help="Run as if Agentflow was started in this directory.",
+        rich_help_panel="Global context",
+    ),
+    verbose: int = typer.Option(
+        0,
+        "--verbose",
+        "-v",
+        count=True,
+        help="Increase diagnostic verbosity; repeat for more detail.",
+        rich_help_panel="Diagnostics",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress informational, progress, and success output.",
+        rich_help_panel="Global output",
+    ),
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        help="Enable debug diagnostics.",
+        rich_help_panel="Diagnostics",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Accept recommended defaults for supported workflows.",
+        rich_help_panel="Global context",
+    ),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Never prompt for input.",
+        rich_help_panel="Global context",
+    ),
+    version_flag: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        is_eager=True,
+        help="Show the CLI version and exit.",
+        rich_help_panel="Global options",
+    ),
+) -> None:
+    """Resolve invocation-wide terminal, logging, and working-directory policy."""
+    if cwd is not None:
+        os.chdir(cwd)
+
+    preferences = UserConfigStore()
+    try:
+        if json_output and output_format not in {None, OutputFormat.JSON}:
+            raise typer.BadParameter("--json cannot be combined with a different --format.")
+        if no_color and color not in {None, ColorMode.NEVER}:
+            raise typer.BadParameter("--no-color cannot be combined with a different --color.")
+        resolved_format = output_format or OutputFormat(
+            preferences.get("output.format", OutputFormat.HUMAN)
+        )
+        resolved_color = color or ColorMode(preferences.get("output.color", ColorMode.AUTO))
+        resolved_progress = progress or ProgressMode(
+            preferences.get("output.progress", ProgressMode.AUTO)
+        )
+        if json_output:
+            resolved_format = OutputFormat.JSON
+        if no_color:
+            resolved_color = ColorMode.NEVER
+    except (ConfigurationError, ValueError) as exc:
+        if ctx.invoked_subcommand != "config":
+            raise typer.BadParameter(
+                f"Invalid user output configuration: {exc}. Run `agentflow config validate`."
+            ) from exc
+        resolved_format = output_format or OutputFormat.HUMAN
+        resolved_color = color or ColorMode.AUTO
+        resolved_progress = progress or ProgressMode.AUTO
+
+    output.configure(
+        output_format=resolved_format,
+        color_mode=resolved_color,
+        progress_mode=resolved_progress,
+        quiet=quiet,
+    )
+    setup_cli_logging(verbose=verbose > 0 or debug, quiet=quiet)
+    ctx.obj = CLIContext.create(
+        capabilities=output.capabilities,
+        cwd=Path.cwd(),
+        verbosity=verbose,
+        quiet=quiet,
+        debug=debug,
+        yes=yes,
+        non_interactive=non_interactive,
+    )
+
+    if version_flag:
+        typer.echo(CLI_VERSION)
+        raise typer.Exit()
+
+
+@config_app.command("path")
+def config_path() -> None:
+    """Print the user configuration file path."""
+    typer.echo(UserConfigStore().path)
+
+
+@config_app.command("list")
+def config_list() -> None:
+    """List all user-level CLI preferences."""
+    store = UserConfigStore()
+    try:
+        values = store.load()
+    except ConfigurationError as exc:
+        raise typer.Exit(handle_exception(exc)) from exc
+    output.print_key_value_pairs(_flatten_mapping(values), title="User configuration")
+
+
+@config_app.command("get")
+def config_get(key: str = typer.Argument(..., help="Dot-separated preference key.")) -> None:
+    """Read one user-level CLI preference."""
+    store = UserConfigStore()
+    try:
+        value = store.get(key)
+    except ConfigurationError as exc:
+        raise typer.Exit(handle_exception(exc)) from exc
+    if value is None:
+        raise typer.Exit(
+            handle_exception(
+                ConfigurationError(
+                    f"Configuration key '{key}' is not set.",
+                    config_path=str(store.path),
+                )
+            )
+        )
+    if isinstance(value, dict | list):
+        typer.echo(json.dumps(value, indent=2, ensure_ascii=False))
+    else:
+        typer.echo(value)
+
+
+@config_app.command("set")
+def config_set(
+    key: str = typer.Argument(..., help="Dot-separated preference key."),
+    value: str = typer.Argument(..., help="JSON value or plain string."),
+) -> None:
+    """Set one user-level CLI preference."""
+    store = UserConfigStore()
+    try:
+        store.set(key, parse_config_value(value))
+    except ConfigurationError as exc:
+        raise typer.Exit(handle_exception(exc)) from exc
+    output.success(f"Set {key} in {store.path}")
+
+
+@config_app.command("unset")
+def config_unset(key: str = typer.Argument(..., help="Dot-separated preference key.")) -> None:
+    """Remove one user-level CLI preference."""
+    store = UserConfigStore()
+    try:
+        removed = store.unset(key)
+    except ConfigurationError as exc:
+        raise typer.Exit(handle_exception(exc)) from exc
+    if not removed:
+        raise typer.Exit(
+            handle_exception(
+                ConfigurationError(
+                    f"Configuration key '{key}' is not set.",
+                    config_path=str(store.path),
+                )
+            )
+        )
+    output.success(f"Removed {key} from {store.path}")
+
+
+@config_app.command("validate")
+def config_validate() -> None:
+    """Validate the user configuration and supported output preferences."""
+    store = UserConfigStore()
+    try:
+        store.load()
+        OutputFormat(store.get("output.format", OutputFormat.HUMAN))
+        ColorMode(store.get("output.color", ColorMode.AUTO))
+        ProgressMode(store.get("output.progress", ProgressMode.AUTO))
+    except (ConfigurationError, ValueError) as exc:
+        raise typer.Exit(handle_exception(ConfigurationError(str(exc)))) from exc
+    output.success(f"User configuration is valid: {store.path}")
+
+
+def _flatten_mapping(
+    values: dict[str, Any],
+    *,
+    prefix: str = "",
+) -> dict[str, Any]:
+    flattened: dict[str, Any] = {}
+    for key, value in values.items():
+        dotted = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            flattened.update(_flatten_mapping(value, prefix=dotted))
+        else:
+            flattened[dotted] = value
+    return flattened
+
+
+def _configure_command(*, verbose: bool, quiet: bool) -> None:
+    """Apply legacy per-command flags without overriding root output choices."""
+    setup_cli_logging(verbose=verbose, quiet=quiet)
+    if quiet:
+        output.configure(quiet=True)
 
 
 def handle_exception(e: Exception) -> int:
@@ -50,10 +350,14 @@ def handle_exception(e: Exception) -> int:
         Appropriate exit code
     """
     if isinstance(e, AgentflowCLIError):
-        output.error(e.message)
+        output.error(f"Error [{e.code}]: {e.message}", emoji=False)
+        for hint in e.hints:
+            output.info(f"Try: {hint}", emoji=False)
+        if e.docs_url:
+            output.info(f"Docs: {e.docs_url}", emoji=False)
         return e.exit_code
 
-    output.error(f"Unexpected error: {e}")
+    output.error(f"Error [AF-INTERNAL-001]: Unexpected error: {e}", emoji=False)
     return 1
 
 
@@ -98,7 +402,7 @@ def api(
 ) -> None:
     """Start the Agentflow API server."""
     # Setup logging
-    setup_cli_logging(verbose=verbose, quiet=quiet)
+    _configure_command(verbose=verbose, quiet=quiet)
 
     try:
         command = APICommand(output)
@@ -155,7 +459,7 @@ def play(
     ),
 ) -> None:
     """Start the API server and open the hosted playground."""
-    setup_cli_logging(verbose=verbose, quiet=quiet)
+    _configure_command(verbose=verbose, quiet=quiet)
 
     try:
         command = APICommand(output)
@@ -167,6 +471,79 @@ def play(
             open_playground=True,
         )
         sys.exit(exit_code)
+    except Exception as e:
+        sys.exit(handle_exception(e))
+
+
+@app.command()
+def dev(
+    config: str = typer.Option(
+        DEFAULT_CONFIG_FILE,
+        "--config",
+        "-c",
+        help="Path to the project configuration file.",
+    ),
+    host: str = typer.Option(
+        DEFAULT_HOST,
+        "--host",
+        "-H",
+        help="Host interface for the local development server.",
+    ),
+    port: int = typer.Option(
+        DEFAULT_PORT,
+        "--port",
+        "-p",
+        help="Port for the local development server.",
+    ),
+    reload: bool = typer.Option(
+        True,
+        "--reload/--no-reload",
+        help="Reload the server when project files change.",
+    ),
+    open_playground: bool = typer.Option(
+        True,
+        "--open/--no-open",
+        help="Open the hosted playground when the API is ready.",
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging."),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress all output except errors.",
+    ),
+) -> None:
+    """Start the local Agentflow development server."""
+    _configure_command(verbose=verbose, quiet=quiet)
+
+    try:
+        command = APICommand(output)
+        exit_code = command.execute(
+            config=config,
+            host=host,
+            port=port,
+            reload=reload,
+            open_playground=open_playground,
+        )
+        sys.exit(exit_code)
+    except Exception as e:
+        sys.exit(handle_exception(e))
+
+
+@app.command()
+def doctor(
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging."),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress all output except errors.",
+    ),
+) -> None:
+    """Diagnose package compatibility and the current project environment."""
+    _configure_command(verbose=verbose, quiet=quiet)
+    try:
+        sys.exit(DoctorCommand(output).execute())
     except Exception as e:
         sys.exit(handle_exception(e))
 
@@ -188,7 +565,7 @@ def version(
 ) -> None:
     """Show the CLI version."""
     # Setup logging
-    setup_cli_logging(verbose=verbose, quiet=quiet)
+    _configure_command(verbose=verbose, quiet=quiet)
 
     try:
         command = VersionCommand(output)
@@ -199,7 +576,8 @@ def version(
 
 
 @app.command()
-def init(
+def init(  # noqa: PLR0913
+    ctx: typer.Context,
     path: str = typer.Option(
         ".",
         "--path",
@@ -211,6 +589,42 @@ def init(
         "--force",
         "-f",
         help="Overwrite existing files if they exist",
+    ),
+    name: str | None = typer.Option(
+        None,
+        "--name",
+        help="Agent name; required only when a default cannot be inferred.",
+    ),
+    template: str | None = typer.Option(
+        None,
+        "--template",
+        help="Project template: quick-start or production.",
+    ),
+    auth: str | None = typer.Option(
+        None,
+        "--auth",
+        help="Production authentication: none, jwt, or custom.",
+    ),
+    rate_limit: str | None = typer.Option(
+        None,
+        "--rate-limit",
+        help="Rate limiting: none, memory, or redis.",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Accept recommended defaults and do not prompt.",
+    ),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Fail instead of prompting; suitable for CI and coding agents.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview the scaffold without writing files.",
     ),
     verbose: bool = typer.Option(
         False,
@@ -226,11 +640,25 @@ def init(
     ),
 ) -> None:
     """Interactively initialize a new agent project."""
-    setup_cli_logging(verbose=verbose, quiet=quiet)
+    _configure_command(verbose=verbose, quiet=quiet)
+    runtime = ctx.find_root().obj
+    if isinstance(runtime, CLIContext):
+        yes = yes or runtime.yes
+        non_interactive = non_interactive or runtime.non_interactive
 
     try:
         command = InitCommand(output)
-        exit_code = command.execute(path=path, force=force)
+        exit_code = command.execute(
+            path=path,
+            force=force,
+            agent_name=name,
+            template=template,
+            auth=auth,
+            rate_limit=rate_limit,
+            yes=yes,
+            non_interactive=non_interactive,
+            dry_run=dry_run,
+        )
         sys.exit(exit_code)
     except Exception as e:
         sys.exit(handle_exception(e))
@@ -294,7 +722,7 @@ def build(
 ) -> None:
     """Generate a Dockerfile for the Agentflow API application."""
     # Setup logging
-    setup_cli_logging(verbose=verbose, quiet=quiet)
+    _configure_command(verbose=verbose, quiet=quiet)
 
     try:
         command = BuildCommand(output)
@@ -357,7 +785,7 @@ def skills(
     ),
 ) -> None:
     """Install bundled Agentflow skills for Codex, Claude, or GitHub."""
-    setup_cli_logging(verbose=verbose, quiet=quiet)
+    _configure_command(verbose=verbose, quiet=quiet)
 
     try:
         command = SkillsCommand(output)
@@ -393,7 +821,7 @@ def test(
 
     Any arguments after -- are forwarded verbatim to pytest.
     """
-    setup_cli_logging(verbose=verbose, quiet=quiet)
+    _configure_command(verbose=verbose, quiet=quiet)
 
     try:
         command = TestCommand(output)
@@ -466,7 +894,7 @@ def eval_cmd(
       EVAL_CONFIG + get_eval_set()       # same, config as a constant
       any function returning EvalSet     # auto-discovered, pytest-style
     """
-    setup_cli_logging(verbose=verbose, quiet=quiet)
+    _configure_command(verbose=verbose, quiet=quiet)
 
     try:
         command = EvalCommand(output)

--- a/agentflow_cli/cli/main.py
+++ b/agentflow_cli/cli/main.py
@@ -132,12 +132,12 @@ def root(  # noqa: PLR0913
         help="Enable or disable decorative command animation.",
         rich_help_panel="Global output",
     ),
-    fullscreen: bool = typer.Option(
-        False,
-        "--fullscreen",
+    fullscreen: bool | None = typer.Option(
+        None,
+        "--fullscreen/--no-fullscreen",
         help=(
-            "Run the command on a dedicated alternate screen and hold it "
-            "until you press Enter."
+            "Run the command on a dedicated full-screen surface with pinned "
+            "header and footer. Enabled by default on an interactive terminal."
         ),
         rich_help_panel="Global output",
     ),
@@ -248,12 +248,15 @@ def root(  # noqa: PLR0913
         yes=yes,
         non_interactive=non_interactive,
     )
-    # Opt-in only: an alternate screen is discarded by the terminal when it is
-    # released, so holding one for the whole command would erase that command's
-    # output on exit. The default experience animates on a temporary screen and
-    # writes every durable line to the normal buffer instead.
-    if (fullscreen or truthy_env("AGENTFLOW_FULLSCREEN")) and output.start_fullscreen_session():
-        ctx.call_on_close(output.end_fullscreen_session)
+    # A terminal discards an alternate screen when it is released, so the frame
+    # pauses on a closing hint before letting go. Anyone who wants output left in
+    # their scrollback — to copy a path, or scroll back after the fact — opts out
+    # with --no-fullscreen or AGENTFLOW_NO_FULLSCREEN=1. The screen itself is
+    # claimed lazily, by the first command that renders a header.
+    if fullscreen is None:
+        fullscreen = not truthy_env("AGENTFLOW_NO_FULLSCREEN")
+    output.request_fullscreen(fullscreen)
+    ctx.call_on_close(output.end_fullscreen_session)
 
     if version_flag:
         typer.echo(CLI_VERSION)
@@ -968,6 +971,12 @@ def main() -> None:
         sys.exit(130)
     except Exception as e:
         sys.exit(handle_exception(e))
+    finally:
+        # Last line of defence. A full-screen session leaves the terminal on an
+        # alternate buffer with a restricted scrolling region; if any path skips
+        # the normal teardown, the user's shell inherits both. Closing here is
+        # idempotent, so the usual context callback still owns the happy path.
+        output.end_fullscreen_session()
 
 
 if __name__ == "__main__":

--- a/agentflow_cli/cli/main.py
+++ b/agentflow_cli/cli/main.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import typer
 
-from agentflow_cli.cli.capabilities import ColorMode, OutputFormat, ProgressMode
+from agentflow_cli.cli.capabilities import ColorMode, OutputFormat, ProgressMode, truthy_env
 from agentflow_cli.cli.constants import (
     CLI_VERSION,
     DEFAULT_CONFIG_FILE,
@@ -132,6 +132,15 @@ def root(  # noqa: PLR0913
         help="Enable or disable decorative command animation.",
         rich_help_panel="Global output",
     ),
+    fullscreen: bool = typer.Option(
+        False,
+        "--fullscreen",
+        help=(
+            "Run the command on a dedicated alternate screen and hold it "
+            "until you press Enter."
+        ),
+        rich_help_panel="Global output",
+    ),
     cwd: Path | None = typer.Option(
         None,
         "--cwd",
@@ -239,7 +248,11 @@ def root(  # noqa: PLR0913
         yes=yes,
         non_interactive=non_interactive,
     )
-    if output.start_fullscreen_session():
+    # Opt-in only: an alternate screen is discarded by the terminal when it is
+    # released, so holding one for the whole command would erase that command's
+    # output on exit. The default experience animates on a temporary screen and
+    # writes every durable line to the normal buffer instead.
+    if (fullscreen or truthy_env("AGENTFLOW_FULLSCREEN")) and output.start_fullscreen_session():
         ctx.call_on_close(output.end_fullscreen_session)
 
     if version_flag:

--- a/agentflow_cli/cli/main.py
+++ b/agentflow_cli/cli/main.py
@@ -58,6 +58,7 @@ def _lazy_command(module_name: str, class_name: str) -> type:
 
 APICommand = _lazy_command("agentflow_cli.cli.commands.api", "APICommand")
 BuildCommand = _lazy_command("agentflow_cli.cli.commands.build", "BuildCommand")
+DemoCommand = _lazy_command("agentflow_cli.cli.commands.demo", "DemoCommand")
 EvalCommand = _lazy_command("agentflow_cli.cli.commands.eval", "EvalCommand")
 DoctorCommand = _lazy_command("agentflow_cli.cli.commands.doctor", "DoctorCommand")
 InitCommand = _lazy_command("agentflow_cli.cli.commands.init", "InitCommand")
@@ -238,6 +239,8 @@ def root(  # noqa: PLR0913
         yes=yes,
         non_interactive=non_interactive,
     )
+    if output.start_fullscreen_session():
+        ctx.call_on_close(output.end_fullscreen_session)
 
     if version_flag:
         typer.echo(CLI_VERSION)
@@ -558,6 +561,21 @@ def doctor(
     _configure_command(verbose=verbose, quiet=quiet)
     try:
         sys.exit(DoctorCommand(output).execute())
+    except Exception as e:
+        sys.exit(handle_exception(e))
+
+
+@app.command(rich_help_panel="Diagnostics")
+def demo(
+    style: str = typer.Option(
+        "all",
+        "--style",
+        help="Animation theme: all, typing, network, init, build, or eval.",
+    ),
+) -> None:
+    """Preview Agentflow terminal animations without changing project state."""
+    try:
+        sys.exit(DemoCommand(output).execute(style=style))
     except Exception as e:
         sys.exit(handle_exception(e))
 

--- a/agentflow_cli/cli/user_config.py
+++ b/agentflow_cli/cli/user_config.py
@@ -1,0 +1,116 @@
+"""Cross-platform user preferences for the Agentflow CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from platformdirs import user_config_path
+
+from agentflow_cli.cli.exceptions import ConfigurationError
+
+
+class UserConfigStore:
+    """Read and atomically update non-secret per-user CLI preferences."""
+
+    SCHEMA_VERSION = 1
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or user_config_path("agentflow", "10xscale") / "config.json"
+
+    def load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"schema_version": self.SCHEMA_VERSION}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ConfigurationError(
+                f"Could not read user configuration at {self.path}: {exc}",
+                config_path=str(self.path),
+            ) from exc
+        if not isinstance(raw, dict):
+            raise ConfigurationError(
+                f"User configuration at {self.path} must be a JSON object.",
+                config_path=str(self.path),
+            )
+        return raw
+
+    def get(self, key: str, default: Any = None) -> Any:
+        value: Any = self.load()
+        for part in key.split("."):
+            if not isinstance(value, dict) or part not in value:
+                return default
+            value = value[part]
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        data = self.load()
+        target = data
+        parts = key.split(".")
+        if not all(parts):
+            raise ConfigurationError("Configuration key cannot be empty.")
+        for part in parts[:-1]:
+            existing = target.get(part)
+            if existing is None:
+                existing = {}
+                target[part] = existing
+            if not isinstance(existing, dict):
+                raise ConfigurationError(
+                    f"Cannot set '{key}': '{part}' already contains a scalar value.",
+                    config_path=str(self.path),
+                )
+            target = existing
+        target[parts[-1]] = value
+        data["schema_version"] = self.SCHEMA_VERSION
+        self._write(data)
+
+    def unset(self, key: str) -> bool:
+        data = self.load()
+        target: Any = data
+        parts = key.split(".")
+        for part in parts[:-1]:
+            if not isinstance(target, dict) or part not in target:
+                return False
+            target = target[part]
+        if not isinstance(target, dict) or parts[-1] not in target:
+            return False
+        del target[parts[-1]]
+        self._write(data)
+        return True
+
+    def _write(self, data: dict[str, Any]) -> None:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            fd, temporary_name = tempfile.mkstemp(
+                prefix=f".{self.path.name}.",
+                suffix=".tmp",
+                dir=self.path.parent,
+                text=True,
+            )
+            temporary_path = Path(temporary_name)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                    json.dump(data, handle, indent=2, ensure_ascii=False, sort_keys=True)
+                    handle.write("\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                temporary_path.replace(self.path)
+            finally:
+                if temporary_path.exists():
+                    temporary_path.unlink()
+        except OSError as exc:
+            raise ConfigurationError(
+                f"Could not write user configuration at {self.path}: {exc}",
+                config_path=str(self.path),
+            ) from exc
+
+
+def parse_config_value(value: str) -> Any:
+    """Parse JSON scalars/containers while retaining ordinary strings."""
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "fastapi>=0.116,<1.0",
     "gunicorn>=23.0,<24",
     "orjson>=3.11,<4",
+    "platformdirs>=4.0,<5",
     "python-multipart>=0.0.19,<0.1",
     "pydantic>=2.13,<3",
     "pydantic-settings>=2.3,<3",
@@ -48,6 +49,7 @@ dependencies = [
     "typer>=0.17,<1.0",
     "python-dotenv>=1.0,<2",
     "questionary>=2.0,<3",
+    "rich>=14.0,<15",
 ]
 
 [project.urls]

--- a/tests/cli/test_cli_api_env.py
+++ b/tests/cli/test_cli_api_env.py
@@ -1,5 +1,5 @@
+import io
 import os
-from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -7,35 +7,13 @@ import pytest
 import agentflow_cli.cli.commands.api as api_mod
 from agentflow_cli.cli.commands.api import APICommand
 from agentflow_cli.cli.core import validation as validation_module
-
-
-class SilentOutput:
-    def command_header(self, *_, **__):
-        pass
-
-    @contextmanager
-    def activity(self, *_, **__):
-        yield None
-
-    def completion_screen(self, *_, **__):
-        pass
-
-    def error(self, *_):
-        pass
-
-    def success(self, *_):
-        pass
-
-    def info(self, *_):
-        pass
-
-    def warning(self, *_):
-        pass
+from agentflow_cli.cli.core.output import OutputFormatter
 
 
 @pytest.fixture
 def silent_output():
-    return SilentOutput()
+    """A real formatter with output suppressed, so it tracks the live surface."""
+    return OutputFormatter(stream=io.StringIO(), quiet=True)
 
 
 def test_api_command_with_env_file(monkeypatch, tmp_path, silent_output):

--- a/tests/cli/test_cli_api_env.py
+++ b/tests/cli/test_cli_api_env.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -9,7 +10,14 @@ from agentflow_cli.cli.core import validation as validation_module
 
 
 class SilentOutput:
-    def print_banner(self, *_, **__):
+    def command_header(self, *_, **__):
+        pass
+
+    @contextmanager
+    def activity(self, *_, **__):
+        yield None
+
+    def completion_screen(self, *_, **__):
         pass
 
     def error(self, *_):
@@ -19,6 +27,9 @@ class SilentOutput:
         pass
 
     def info(self, *_):
+        pass
+
+    def warning(self, *_):
         pass
 
 

--- a/tests/cli/test_cli_commands_ops.py
+++ b/tests/cli/test_cli_commands_ops.py
@@ -196,12 +196,29 @@ def test_init_command_prod(monkeypatch, tmp_path, silent_output):
     )
 
 
-def test_init_command_existing_without_force(tmp_path, silent_output):
+def test_init_command_existing_without_force(monkeypatch, tmp_path, silent_output):
+    ctx = {
+        "agent_name": "MyAgent",
+        "agent_name_slug": "my-agent",
+        "setup_type": "quick_start",
+        "auth": "none",
+        "rate_limit": "none",
+    }
+    monkeypatch.setattr(InitCommand, "_prompt_user", lambda self: ctx)
     cfg = tmp_path / "agentflow.json"
     cfg.write_text("{}", encoding="utf-8")
     cmd = InitCommand(output=silent_output)
     code = cmd.execute(path=str(tmp_path), force=False)
     assert code == 1
+
+
+def test_init_without_a_terminal_explains_the_flag_alternative(tmp_path, silent_output):
+    """No TTY and no --yes/--non-interactive is a usage problem with a fix."""
+    cmd = InitCommand(output=silent_output)
+    code = cmd.execute(path=str(tmp_path), force=False)
+
+    assert code == 3
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_build_command_basic_no_requirements(tmp_path, monkeypatch, silent_output):

--- a/tests/cli/test_cli_demo.py
+++ b/tests/cli/test_cli_demo.py
@@ -1,0 +1,39 @@
+"""Tests for the side-effect-free terminal animation showcase."""
+
+from __future__ import annotations
+
+import io
+
+from agentflow_cli.cli.commands import demo as demo_module
+from agentflow_cli.cli.commands.demo import DemoCommand
+from agentflow_cli.cli.core.output import OutputFormatter
+
+
+def test_demo_renders_all_themes_without_side_effects(monkeypatch) -> None:
+    monkeypatch.setattr(demo_module.time, "sleep", lambda _seconds: None)
+    stream = io.StringIO()
+    command = DemoCommand(OutputFormatter(stream=stream))
+
+    assert command.execute() == 0
+    rendered = stream.getvalue()
+    for theme in ("Typing", "Api", "Init", "Build", "Eval"):
+        assert theme in rendered
+    assert "All preview states rendered successfully" in rendered
+    assert "none" in rendered
+
+
+def test_demo_rejects_unknown_style() -> None:
+    stream = io.StringIO()
+    command = DemoCommand(OutputFormatter(stream=stream))
+
+    assert command.execute(style="unknown") != 0
+    assert "Unknown animation style" in stream.getvalue()
+
+
+def test_play_alias_selects_typing_theme(monkeypatch) -> None:
+    monkeypatch.setattr(demo_module.time, "sleep", lambda _seconds: None)
+    stream = io.StringIO()
+    command = DemoCommand(OutputFormatter(stream=stream))
+
+    assert command.execute(style="play") == 0
+    assert "Typing" in stream.getvalue()

--- a/tests/cli/test_cli_runtime.py
+++ b/tests/cli/test_cli_runtime.py
@@ -41,6 +41,12 @@ def test_plain_and_no_color_global_options() -> None:
     assert "Version" in result.output
 
 
+def test_no_animation_alias_selects_static_output() -> None:
+    result = runner.invoke(main_mod.app, ["--no-animation", "doctor"])
+    assert result.exit_code == 0
+    assert "Doctor" in result.output
+
+
 def test_dev_delegates_to_api_with_open_policy(monkeypatch) -> None:
     called = {}
     monkeypatch.setattr(main_mod, "setup_cli_logging", lambda **kwargs: None)

--- a/tests/cli/test_cli_runtime.py
+++ b/tests/cli/test_cli_runtime.py
@@ -25,7 +25,7 @@ def test_root_help_does_not_import_command_implementations(monkeypatch) -> None:
     assert result.exit_code == 0
     assert imported == []
     assert "dev" in result.output
-    assert "doctor" in result.output
+    assert "audit" in result.output
 
 
 def test_root_version_is_script_friendly() -> None:
@@ -42,9 +42,9 @@ def test_plain_and_no_color_global_options() -> None:
 
 
 def test_no_animation_alias_selects_static_output() -> None:
-    result = runner.invoke(main_mod.app, ["--no-animation", "doctor"])
+    result = runner.invoke(main_mod.app, ["--no-animation", "audit"])
     assert result.exit_code == 0
-    assert "Doctor" in result.output
+    assert "Audit" in result.output
 
 
 def test_dev_delegates_to_api_with_open_policy(monkeypatch) -> None:
@@ -73,7 +73,7 @@ def test_lazy_dependency_error_has_recovery_code(monkeypatch) -> None:
     result = runner.invoke(main_mod.app, ["eval"])
     assert result.exit_code == 4
     assert "AF-DEPS-001" in result.output
-    assert "agentflow doctor" in result.output
+    assert "agentflow audit" in result.output
 
 
 def test_config_commands_round_trip(monkeypatch, tmp_path) -> None:

--- a/tests/cli/test_cli_runtime.py
+++ b/tests/cli/test_cli_runtime.py
@@ -1,0 +1,94 @@
+"""Root runtime, startup isolation, and new command contract tests."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+import agentflow_cli.cli.main as main_mod
+from agentflow_cli.cli.user_config import UserConfigStore
+
+
+runner = CliRunner()
+
+
+def test_root_help_does_not_import_command_implementations(monkeypatch) -> None:
+    imported: list[str] = []
+    original = main_mod.importlib.import_module
+
+    def recording_import(name: str, *args, **kwargs):
+        if name.startswith("agentflow_cli.cli.commands."):
+            imported.append(name)
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(main_mod.importlib, "import_module", recording_import)
+    result = runner.invoke(main_mod.app, ["--help"])
+    assert result.exit_code == 0
+    assert imported == []
+    assert "dev" in result.output
+    assert "doctor" in result.output
+
+
+def test_root_version_is_script_friendly() -> None:
+    result = runner.invoke(main_mod.app, ["--version"])
+    assert result.exit_code == 0
+    assert result.output.strip() == main_mod.CLI_VERSION
+
+
+def test_plain_and_no_color_global_options() -> None:
+    result = runner.invoke(main_mod.app, ["--format", "plain", "--color", "never", "version"])
+    assert result.exit_code == 0
+    assert "\x1b[" not in result.output
+    assert "Version" in result.output
+
+
+def test_dev_delegates_to_api_with_open_policy(monkeypatch) -> None:
+    called = {}
+    monkeypatch.setattr(main_mod, "setup_cli_logging", lambda **kwargs: None)
+    monkeypatch.setattr(
+        main_mod.APICommand,
+        "execute",
+        lambda self, **kwargs: called.update(kwargs) or 0,
+    )
+    result = runner.invoke(main_mod.app, ["dev", "--no-open", "--port", "8123"])
+    assert result.exit_code == 0
+    assert called["open_playground"] is False
+    assert called["port"] == 8123
+
+
+def test_lazy_dependency_error_has_recovery_code(monkeypatch) -> None:
+    original = main_mod.importlib.import_module
+
+    def fail_eval(name: str, *args, **kwargs):
+        if name == "agentflow_cli.cli.commands.eval":
+            raise ImportError("missing evaluation symbol")
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(main_mod.importlib, "import_module", fail_eval)
+    result = runner.invoke(main_mod.app, ["eval"])
+    assert result.exit_code == 4
+    assert "AF-DEPS-001" in result.output
+    assert "agentflow doctor" in result.output
+
+
+def test_config_commands_round_trip(monkeypatch, tmp_path) -> None:
+    store = UserConfigStore(tmp_path / "config.json")
+    monkeypatch.setattr(main_mod, "UserConfigStore", lambda: store)
+
+    set_result = runner.invoke(main_mod.app, ["config", "set", "output.format", "plain"])
+    assert set_result.exit_code == 0
+    assert store.get("output.format") == "plain"
+
+    get_result = runner.invoke(main_mod.app, ["config", "get", "output.format"])
+    assert get_result.exit_code == 0
+    assert get_result.output.strip() == "plain"
+
+    list_result = runner.invoke(main_mod.app, ["config", "list"])
+    assert list_result.exit_code == 0
+    assert "output.format" in list_result.output
+
+    validate_result = runner.invoke(main_mod.app, ["config", "validate"])
+    assert validate_result.exit_code == 0
+
+    unset_result = runner.invoke(main_mod.app, ["config", "unset", "output.format"])
+    assert unset_result.exit_code == 0
+    assert store.get("output.format") is None

--- a/tests/cli/test_cli_version.py
+++ b/tests/cli/test_cli_version.py
@@ -15,8 +15,8 @@ class StubOutput:
         self.error_messages = []
 
     # Methods used by VersionCommand
-    def print_banner(self, title, subtitle, color=""):
-        self.banner_args.append((title, subtitle, color))
+    def command_header(self, command, subtitle, color=""):
+        self.banner_args.append((command.title(), subtitle, color))
 
     def success(self, msg):
         self.success_messages.append(msg)

--- a/tests/cli/test_eval_command.py
+++ b/tests/cli/test_eval_command.py
@@ -79,19 +79,19 @@ def test_load_agent_from_config_invalid_spec(cmd):
             cmd._load_agent_from_config()
 
 
-def test_print_criteria_block(cmd, capsys):
+def test_print_criteria_block(cmd):
     cfg = EvalConfig(
         criteria=CriteriaConfig(
             tool_name_match=CriterionConfig.tool_name_match(threshold=1.0),
         )
     )
     cmd._print_criteria_block(cfg, Path("some_dir"))
-    captured = capsys.readouterr()
-    assert "Criteria  source:" in captured.out
-    assert "tool_name_match" in captured.out
+    rendered = "\n".join(cmd.output.infos)
+    assert "Criteria  source:" in rendered
+    assert "tool_name_match" in rendered
 
 
-def test_print_case_progress_passed(cmd, capsys):
+def test_print_case_progress_passed(cmd):
     res = EvalCaseResult.success(
         eval_id="c1",
         name="case1",
@@ -100,9 +100,9 @@ def test_print_case_progress_passed(cmd, capsys):
     )
     res.duration_seconds = 1.23
     cmd._print_case_progress("file.py", "case1", res, 1, 10)
-    captured = capsys.readouterr()
-    assert "file.py::case1" in captured.out
-    assert "PASSED" in captured.out
+    rendered = "\n".join(cmd.output.infos)
+    assert "file.py::case1" in rendered
+    assert "PASSED" in rendered
 
 
 def test_resolve_eval_dir(cmd):
@@ -467,7 +467,7 @@ def test_make_pending_loads_agent_from_config(cmd):
         assert res[0].evaluator.graph is mock_agent
 
 
-def test_print_criteria_block_custom(cmd, capsys):
+def test_print_criteria_block_custom(cmd):
     cfg_match = CriterionConfig.tool_name_match(threshold=1.0)
     cfg_match.num_samples = 3
     cfg_match.judge_model = "gpt-4"
@@ -477,9 +477,9 @@ def test_print_criteria_block_custom(cmd, capsys):
         )
     )
     cmd._print_criteria_block(cfg, Path("some_dir"))
-    captured = capsys.readouterr()
-    assert "samples=3" in captured.out
-    assert "judge=gpt-4" in captured.out
+    rendered = "\n".join(cmd.output.infos)
+    assert "samples=3" in rendered
+    assert "judge=gpt-4" in rendered
 
 
 def _pending_case(file_name, config, source):
@@ -494,7 +494,7 @@ def _pending_case(file_name, config, source):
     )
 
 
-def test_print_criteria_per_file_shows_each_files_criteria(cmd, capsys):
+def test_print_criteria_per_file_shows_each_files_criteria(cmd):
     tool_cfg = EvalConfig(
         criteria=CriteriaConfig(tool_name_match=CriterionConfig.tool_name_match(threshold=0.6))
     )
@@ -506,11 +506,11 @@ def test_print_criteria_per_file_shows_each_files_criteria(cmd, capsys):
         _pending_case("weather_agents_eval.py", rouge_cfg, "confeval.py"),
     ]
     cmd._print_criteria_per_file(pending, Path("evals/confeval.py"))
-    out = capsys.readouterr().out
+    out = "\n".join(cmd.output.infos)
     # Each file is listed with its own criteria and resolved source.
     assert "eval_tool_agents.py  (source: per-file)" in out
     assert "tool_name_match" in out
-    assert "weather_agents_eval.py  (source: evals/confeval.py)" in out
+    assert f"weather_agents_eval.py  (source: {Path('evals/confeval.py')})" in out
     assert "rouge_match" in out
 
 

--- a/tests/cli/test_eval_command.py
+++ b/tests/cli/test_eval_command.py
@@ -91,7 +91,7 @@ def test_print_criteria_block(cmd):
     assert "tool_name_match" in rendered
 
 
-def test_print_case_progress_passed(cmd):
+def test_case_progress_fields_for_a_passing_case(cmd):
     res = EvalCaseResult.success(
         eval_id="c1",
         name="case1",
@@ -99,10 +99,8 @@ def test_print_case_progress_passed(cmd):
         actual_response="",
     )
     res.duration_seconds = 1.23
-    cmd._print_case_progress("file.py", "case1", res, 1, 10)
-    rendered = "\n".join(cmd.output.infos)
-    assert "file.py::case1" in rendered
-    assert "PASSED" in rendered
+    assert cmd._case_status(res) == "passed"
+    assert "1.23s" in cmd._case_detail(res)
 
 
 def test_resolve_eval_dir(cmd):

--- a/tests/cli/test_init_non_interactive.py
+++ b/tests/cli/test_init_non_interactive.py
@@ -1,0 +1,57 @@
+"""Non-interactive and dry-run project initialization."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from agentflow_cli.cli.commands.init import InitCommand
+from agentflow_cli.cli.core.output import OutputFormatter
+
+
+def test_dry_run_does_not_create_target(tmp_path: Path) -> None:
+    target = tmp_path / "preview-agent"
+    stream = io.StringIO()
+    command = InitCommand(OutputFormatter(stream=stream))
+
+    result = command.execute(
+        path=str(target),
+        agent_name="Preview Agent",
+        template="production",
+        auth="jwt",
+        rate_limit="redis",
+        non_interactive=True,
+        dry_run=True,
+    )
+
+    assert result == 0
+    assert not target.exists()
+    assert "Files that would be created" in stream.getvalue()
+    assert "no files were written" in stream.getvalue()
+
+
+def test_non_interactive_quick_start_creates_project(tmp_path: Path) -> None:
+    target = tmp_path / "weather-agent"
+    command = InitCommand(OutputFormatter(stream=io.StringIO()))
+
+    result = command.execute(
+        path=str(target),
+        agent_name="Weather Agent",
+        template="quick-start",
+        non_interactive=True,
+    )
+
+    assert result == 0
+    assert (target / "agentflow.json").exists()
+    assert (target / "graph" / "agent.py").exists()
+
+
+def test_non_interactive_rejects_production_options_on_quick_start(tmp_path: Path) -> None:
+    command = InitCommand(OutputFormatter(stream=io.StringIO()))
+    result = command.execute(
+        path=str(tmp_path / "invalid"),
+        template="quick-start",
+        auth="jwt",
+        non_interactive=True,
+    )
+    assert result != 0

--- a/tests/cli/test_init_prod.py
+++ b/tests/cli/test_init_prod.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
 
 from agentflow_cli.cli.commands.init import InitCommand
 
 
 class SilentOutput:
-    def print_banner(self, *a, **kw):
+    def command_header(self, *a, **kw):
+        pass
+
+    @contextmanager
+    def activity(self, *a, **kw):
+        yield None
+
+    def completion_screen(self, *a, **kw):
         pass
 
     def success(self, *a, **kw):

--- a/tests/cli/test_init_prod.py
+++ b/tests/cli/test_init_prod.py
@@ -2,40 +2,16 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+import io
 from pathlib import Path
 
 from agentflow_cli.cli.commands.init import InitCommand
+from agentflow_cli.cli.core.output import OutputFormatter
 
 
-class SilentOutput:
-    def command_header(self, *a, **kw):
-        pass
-
-    @contextmanager
-    def activity(self, *a, **kw):
-        yield None
-
-    def completion_screen(self, *a, **kw):
-        pass
-
-    def success(self, *a, **kw):
-        pass
-
-    def info(self, *a, **kw):
-        pass
-
-    def warning(self, *a, **kw):
-        pass
-
-    def error(self, *a, **kw):
-        pass
-
-    def print_table(self, *a, **kw):
-        pass
-
-    def print_list(self, *a, **kw):
-        pass
+def SilentOutput() -> OutputFormatter:
+    """A real formatter with output suppressed, so it tracks the live surface."""
+    return OutputFormatter(stream=io.StringIO(), quiet=True)
 
 
 def _skip_binary(original):

--- a/tests/cli/test_init_prod.py
+++ b/tests/cli/test_init_prod.py
@@ -23,6 +23,12 @@ class SilentOutput:
     def error(self, *a, **kw):
         pass
 
+    def print_table(self, *a, **kw):
+        pass
+
+    def print_list(self, *a, **kw):
+        pass
+
 
 def _skip_binary(original):
     """Wrap _should_skip to also exclude non-text template artifacts."""

--- a/tests/cli/test_skills.py
+++ b/tests/cli/test_skills.py
@@ -12,6 +12,7 @@ import pytest
 from agentflow_cli.cli.commands.skills import SkillsCommand
 from agentflow_cli.cli.constants import CLI_VERSION
 from agentflow_cli.cli.core.output import OutputFormatter
+from agentflow_cli.cli.core.prompts import Choice, PromptService
 
 
 class _CapturingOutput(OutputFormatter):
@@ -25,6 +26,7 @@ class _CapturingOutput(OutputFormatter):
         self.infos: list[str] = []
         self.tables: list[tuple[list[str], list[list[str]]]] = []
         self.lists: list[tuple[str | None, list[str]]] = []
+        self.completions: list[dict[str, object]] = []
 
     def print_banner(self, *args, **kwargs) -> None:  # type: ignore[override]
         return
@@ -46,6 +48,16 @@ class _CapturingOutput(OutputFormatter):
 
     def print_list(self, items, title=None, bullet="-") -> None:  # type: ignore[override]
         self.lists.append((title, list(items)))
+
+    def completion_screen(  # type: ignore[override]
+        self, title, message, *, details=None, next_steps=None
+    ) -> None:
+        self.completions.append({"title": title, "message": message, "details": details or {}})
+
+    @property
+    def last_completion(self) -> dict[str, object]:
+        assert self.completions, "expected the command to render a completion screen"
+        return self.completions[-1]
 
 
 @pytest.fixture
@@ -186,15 +198,16 @@ def test_all_skips_existing_without_force(
     cmd: SkillsCommand, out: _CapturingOutput, tmp_path: Path
 ) -> None:
     cmd.execute(agent="claude", path=str(tmp_path))
-    out.successes.clear()
+    out.completions.clear()
 
     exit_code = cmd.execute(all_agents=True, path=str(tmp_path))
     assert exit_code == 0
     # Codex and GitHub were installed, Claude was skipped
-    installed = " ".join(out.successes)
-    assert "Codex" in installed
-    assert "GitHub" in installed
-    assert "Claude" not in installed
+    details = out.last_completion["details"]
+    assert "Codex" in details["Installed"]
+    assert "GitHub" in details["Installed"]
+    assert "Claude" not in details["Installed"]
+    assert details["Skipped"] == "Claude"
     assert any("Skipped existing" in w and "Claude" in w for w in out.warnings)
 
 
@@ -234,3 +247,88 @@ def test_no_agent_with_non_tty_stdin_errors(
         exit_code = cmd.execute(path=str(tmp_path))
     assert exit_code != 0
     assert any("stdin is not interactive" in e for e in out.errors)
+
+
+# --- interactive multi-select --------------------------------------------
+
+
+def _answer_checkbox(monkeypatch, selection: list[str] | None) -> list[list[Choice]]:
+    """Capture the offered choices and reply with a fixed selection."""
+    offered: list[list[Choice]] = []
+
+    def fake_checkbox(self, message, choices, **kwargs):
+        offered.append(list(choices))
+        return selection
+
+    monkeypatch.setattr(PromptService, "checkbox", fake_checkbox)
+    monkeypatch.setattr(PromptService, "require_interactive", lambda self, **kwargs: None)
+    return offered
+
+
+def test_multi_select_installs_every_chosen_agent(
+    cmd: SkillsCommand, monkeypatch, tmp_path: Path
+) -> None:
+    _answer_checkbox(monkeypatch, ["Codex", "GitHub"])
+
+    assert cmd.execute(path=str(tmp_path)) == 0
+    assert (tmp_path / ".agents" / "skills" / "agentflow" / "SKILL.md").is_file()
+    assert (tmp_path / ".github" / "skills" / "agentflow" / "SKILL.md").is_file()
+    assert not (tmp_path / ".claude").exists()
+
+
+def test_multi_select_marks_already_installed_agents(
+    cmd: SkillsCommand, monkeypatch, tmp_path: Path
+) -> None:
+    cmd.execute(agent="claude", path=str(tmp_path))
+    offered = _answer_checkbox(monkeypatch, ["Codex"])
+
+    cmd.execute(path=str(tmp_path))
+
+    by_name = {choice.value: choice for choice in offered[0]}
+    # An existing install is pre-checked and labelled, so confirming as-is
+    # reinstalls exactly what is already there rather than silently dropping it.
+    assert by_name["Claude"].checked is True
+    assert "(installed)" in by_name["Claude"].description
+    assert by_name["Codex"].checked is False
+    assert "(installed)" not in by_name["Codex"].description
+
+
+def test_cancelling_the_multi_select_writes_nothing(
+    cmd: SkillsCommand, monkeypatch, tmp_path: Path
+) -> None:
+    _answer_checkbox(monkeypatch, None)
+
+    assert cmd.execute(path=str(tmp_path)) == 0
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_declining_the_overwrite_prompt_skips_that_agent(
+    cmd: SkillsCommand, out: _CapturingOutput, monkeypatch, tmp_path: Path
+) -> None:
+    cmd.execute(agent="claude", path=str(tmp_path))
+    sentinel = tmp_path / ".claude" / "skills" / "agentflow" / "SENTINEL.txt"
+    sentinel.write_text("mine", encoding="utf-8")
+
+    _answer_checkbox(monkeypatch, ["Claude"])
+    monkeypatch.setattr(PromptService, "confirm", lambda self, message, **kwargs: False)
+    monkeypatch.setattr(PromptService, "interactive", property(lambda self: True))
+    out.completions.clear()
+
+    assert cmd.execute(path=str(tmp_path)) == 0
+    assert sentinel.exists(), "declining the overwrite must leave existing files alone"
+    assert out.last_completion["details"]["Skipped"] == "Claude"
+
+
+def test_accepting_the_overwrite_prompt_reinstalls(
+    cmd: SkillsCommand, monkeypatch, tmp_path: Path
+) -> None:
+    cmd.execute(agent="claude", path=str(tmp_path))
+    sentinel = tmp_path / ".claude" / "skills" / "agentflow" / "SENTINEL.txt"
+    sentinel.write_text("mine", encoding="utf-8")
+
+    _answer_checkbox(monkeypatch, ["Claude"])
+    monkeypatch.setattr(PromptService, "confirm", lambda self, message, **kwargs: True)
+    monkeypatch.setattr(PromptService, "interactive", property(lambda self: True))
+
+    assert cmd.execute(path=str(tmp_path)) == 0
+    assert not sentinel.exists()

--- a/tests/unit_tests/test_cli_animations.py
+++ b/tests/unit_tests/test_cli_animations.py
@@ -85,7 +85,7 @@ def test_intro_does_not_claim_a_second_screen_when_one_is_already_held() -> None
 
 def test_intro_uses_ascii_only_output_when_unicode_is_unavailable() -> None:
     console, stream = terminal()
-    anim.render_command_intro(console, command="doctor", subtitle="Check it", unicode=False)
+    anim.render_command_intro(console, command="audit", subtitle="Check it", unicode=False)
 
     assert ANSI.sub("", stream.getvalue()).isascii()
 

--- a/tests/unit_tests/test_cli_animations.py
+++ b/tests/unit_tests/test_cli_animations.py
@@ -1,0 +1,175 @@
+"""Tests for the command intro engine and the persistent session header."""
+
+from __future__ import annotations
+
+import io
+import re
+
+import pytest
+from rich.console import Console
+
+from agentflow_cli.cli.core import animations as anim
+from agentflow_cli.cli.core.theme import ASCII_GLYPHS, UNICODE_GLYPHS
+
+
+ALT_SCREEN_ON = "\x1b[?1049h"
+ALT_SCREEN_OFF = "\x1b[?1049l"
+ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+
+@pytest.fixture(autouse=True)
+def _instant_frames(monkeypatch):
+    """Run the choreography without spending its wall-clock motion budget."""
+    monkeypatch.setattr(anim.time, "sleep", lambda _seconds: None)
+
+
+def terminal(width: int = 100, height: int = 30) -> tuple[Console, io.StringIO]:
+    stream = io.StringIO()
+    console = Console(
+        file=stream,
+        force_terminal=True,
+        color_system="truecolor",
+        width=width,
+        height=height,
+        legacy_windows=False,
+    )
+    return console, stream
+
+
+def plain_tail(rendered: str) -> str:
+    """Everything the user still sees after the alternate screen is released."""
+    return ANSI.sub("", rendered.split(ALT_SCREEN_OFF)[-1])
+
+
+def test_intro_releases_every_alternate_screen_it_claims() -> None:
+    console, stream = terminal()
+    anim.render_command_intro(console, command="play", subtitle="Serve it", unicode=True)
+
+    rendered = stream.getvalue()
+    assert rendered.count(ALT_SCREEN_ON) == 1
+    assert rendered.count(ALT_SCREEN_OFF) == 1
+    assert rendered.index(ALT_SCREEN_ON) < rendered.index(ALT_SCREEN_OFF)
+
+
+def test_intro_leaves_a_durable_header_in_the_normal_buffer() -> None:
+    """The bug this guards: an alternate screen discards whatever it held."""
+    console, stream = terminal()
+    anim.render_command_intro(console, command="play", subtitle="Serve it", unicode=True)
+
+    survives = plain_tail(stream.getvalue())
+    assert "play" in survives
+    assert "Serve it" in survives
+    assert UNICODE_GLYPHS.rule in survives
+
+
+def test_intro_falls_back_to_inline_motion_on_a_short_terminal() -> None:
+    console, stream = terminal(height=8)
+    anim.render_command_intro(console, command="init", subtitle=None, unicode=True)
+
+    rendered = stream.getvalue()
+    assert ALT_SCREEN_ON not in rendered
+    assert "init" in ANSI.sub("", rendered)
+
+
+def test_intro_does_not_claim_a_second_screen_when_one_is_already_held() -> None:
+    console, stream = terminal()
+    anim.render_command_intro(
+        console,
+        command="build",
+        subtitle=None,
+        unicode=True,
+        persistent_screen=True,
+    )
+    assert ALT_SCREEN_ON not in stream.getvalue()
+
+
+def test_intro_uses_ascii_only_output_when_unicode_is_unavailable() -> None:
+    console, stream = terminal()
+    anim.render_command_intro(console, command="doctor", subtitle="Check it", unicode=False)
+
+    assert ANSI.sub("", stream.getvalue()).isascii()
+
+
+def test_session_header_reports_the_command_and_version() -> None:
+    console, stream = terminal()
+    anim.render_session_header(
+        console,
+        command="eval",
+        subtitle="Score the agent",
+        glyphs=UNICODE_GLYPHS,
+        version="9.9.9",
+    )
+
+    rendered = ANSI.sub("", stream.getvalue())
+    assert "agentflow" in rendered
+    assert "eval" in rendered
+    assert "Score the agent" in rendered
+    assert "9.9.9" in rendered
+
+
+def test_session_header_omits_the_subtitle_line_when_absent() -> None:
+    console, stream = terminal()
+    anim.render_session_header(
+        console,
+        command="eval",
+        subtitle=None,
+        glyphs=UNICODE_GLYPHS,
+    )
+    lines = [line for line in ANSI.sub("", stream.getvalue()).splitlines() if line.strip()]
+    assert len(lines) == 3
+
+
+def test_wordmark_reveal_advances_with_progress() -> None:
+    hidden = "".join(line.plain for line in anim._block_wordmark(0.0, 0.0, UNICODE_GLYPHS))
+    partial = "".join(line.plain for line in anim._block_wordmark(0.5, 0.0, UNICODE_GLYPHS))
+    full = "".join(line.plain for line in anim._block_wordmark(1.0, 0.0, UNICODE_GLYPHS))
+
+    assert hidden.strip() == ""
+    assert 0 < partial.count(UNICODE_GLYPHS.block) < full.count(UNICODE_GLYPHS.block)
+
+
+def test_wordmark_uses_the_compact_form_without_block_glyphs() -> None:
+    lines = anim._block_wordmark(1.0, 0.0, ASCII_GLYPHS)
+    assert len(lines) == 1
+    assert lines[0].plain.replace(" ", "") == "AGENTFLOW"
+
+
+def test_signature_pipeline_fills_in_step_with_progress() -> None:
+    glyphs = UNICODE_GLYPHS
+    empty = anim._signature_nodes("play", 0.0, glyphs).plain
+    done = anim._signature_nodes("play", 1.0, glyphs).plain
+
+    assert empty.count(glyphs.node) == 0
+    assert done.count(glyphs.node) == len(anim._SIGNATURES["play"])
+
+
+def test_unknown_commands_get_the_default_signature_and_tagline() -> None:
+    assert anim._signature_for("totally-new") == anim._DEFAULT_SIGNATURE
+    console, stream = terminal()
+    anim.render_command_intro(console, command="totally-new", subtitle=None, unicode=True)
+    assert "totally-new" in plain_tail(stream.getvalue())
+
+
+def test_phase_and_easing_stay_within_their_bounds() -> None:
+    assert anim._phase(0.1, 0.2, 0.8) == 0.0
+    assert anim._phase(0.9, 0.2, 0.8) == 1.0
+    assert anim._phase(0.5, 0.0, 1.0) == pytest.approx(0.5)
+    assert anim._ease_out(0.0) == pytest.approx(0.0)
+    assert anim._ease_out(1.0) == pytest.approx(1.0)
+    # Ease-out front-loads the motion, so it is always ahead of linear.
+    assert anim._ease_out(0.5) > 0.5
+
+
+def test_every_cinematic_frame_renders_without_error() -> None:
+    console, stream = terminal()
+    for index in range(11):
+        console.print(
+            anim._cinematic_frame(
+                console,
+                command="play",
+                tagline="Local agent runtime.",
+                glyphs=UNICODE_GLYPHS,
+                progress=index / 10,
+            )
+        )
+    assert stream.getvalue()

--- a/tests/unit_tests/test_cli_capabilities.py
+++ b/tests/unit_tests/test_cli_capabilities.py
@@ -1,0 +1,62 @@
+"""Terminal capability policy tests."""
+
+from __future__ import annotations
+
+import io
+
+from agentflow_cli.cli.capabilities import (
+    ColorMode,
+    OutputFormat,
+    ProgressMode,
+    TerminalCapabilities,
+)
+
+
+class TTYStream(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+def test_interactive_terminal_enables_human_animation(monkeypatch) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    capabilities = TerminalCapabilities.detect(stream=TTYStream())
+    assert capabilities.interactive is True
+    assert capabilities.output_format == OutputFormat.HUMAN
+    assert capabilities.progress_mode == ProgressMode.TTY
+    assert capabilities.animation is True
+
+
+def test_pipe_automatically_uses_plain_output() -> None:
+    capabilities = TerminalCapabilities.detect(stream=io.StringIO())
+    assert capabilities.output_format == OutputFormat.PLAIN
+    assert capabilities.progress_mode == ProgressMode.PLAIN
+    assert capabilities.animation is False
+
+
+def test_ci_disables_interactivity_and_animation(monkeypatch) -> None:
+    monkeypatch.setenv("CI", "true")
+    capabilities = TerminalCapabilities.detect(stream=TTYStream())
+    assert capabilities.is_ci is True
+    assert capabilities.interactive is False
+    assert capabilities.animation is False
+
+
+def test_explicit_color_policy_wins(monkeypatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    capabilities = TerminalCapabilities.detect(
+        stream=io.StringIO(),
+        color_mode=ColorMode.ALWAYS,
+        output_format=OutputFormat.HUMAN,
+    )
+    assert capabilities.color is True
+
+
+def test_structured_output_never_animates() -> None:
+    capabilities = TerminalCapabilities.detect(
+        stream=TTYStream(),
+        output_format=OutputFormat.JSONL,
+        progress_mode=ProgressMode.TTY,
+    )
+    assert capabilities.color is False
+    assert capabilities.animation is False

--- a/tests/unit_tests/test_cli_config_manager.py
+++ b/tests/unit_tests/test_cli_config_manager.py
@@ -53,11 +53,12 @@ class TestConfigManager:
         assert result.exists()
         assert str(result) == temp_config_file
 
-    def test_find_config_file_absolute_path_not_found(self):
+    def test_find_config_file_absolute_path_not_found(self, tmp_path):
         """Test finding config file with non-existent absolute path."""
         manager = ConfigManager()
+        missing = (tmp_path / "missing" / "config.json").resolve()
         with pytest.raises(ConfigurationError) as exc_info:
-            manager.find_config_file("/non/existent/path/config.json")
+            manager.find_config_file(str(missing))
         assert "Config file not found" in str(exc_info.value)
 
     def test_find_config_file_relative_path(self, temp_dir):
@@ -115,6 +116,15 @@ class TestConfigManager:
             assert discovered is None or isinstance(discovered, Path)
         finally:
             os.chdir(old_cwd)
+
+    def test_auto_discover_config_walks_parent_directories(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "agentflow.json"
+        config_path.write_text(json.dumps({"agent": "graph.agent:app"}), encoding="utf-8")
+        nested = tmp_path / "packages" / "worker"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        assert ConfigManager().auto_discover_config() == config_path
 
     def test_load_config_with_path(self, temp_config_file):
         """Test loading config with explicit path."""

--- a/tests/unit_tests/test_cli_logger.py
+++ b/tests/unit_tests/test_cli_logger.py
@@ -1,7 +1,8 @@
-"""Unit tests for CLI logger configuration."""
+"""Tests for centralized CLI logging."""
+
+from __future__ import annotations
 
 import logging
-import sys
 from io import StringIO
 
 from agentflow_cli.cli.logger import (
@@ -12,284 +13,60 @@ from agentflow_cli.cli.logger import (
 )
 
 
-class TestCLILoggerMixin:
-    """Test CLILoggerMixin."""
-
-    def test_mixin_init_creates_logger(self):
-        """Test that mixin initialization creates a logger."""
-
-        class TestCommand(CLILoggerMixin):
-            pass
-
-        command = TestCommand()
-
-        assert hasattr(command, "logger")
-        assert isinstance(command.logger, logging.Logger)
-        assert "TestCommand" in command.logger.name
-
-    def test_mixin_logger_name(self):
-        """Test that mixin logger has correct name format."""
-
-        class MyCommand(CLILoggerMixin):
-            pass
-
-        command = MyCommand()
-
-        assert command.logger.name == "agentflowcli.MyCommand"
-
-
-class TestGetLogger:
-    """Test get_logger function."""
-
-    def test_get_logger_returns_logger(self):
-        """Test that get_logger returns a Logger instance."""
-        logger = get_logger("test_logger")
-
-        assert isinstance(logger, logging.Logger)
-        assert "test_logger" in logger.name
-
-    def test_get_logger_with_custom_level(self):
-        """Test get_logger with custom logging level."""
-        logger = get_logger("debug_logger", level=logging.DEBUG)
-
-        assert logger.level == logging.DEBUG
-
-    def test_get_logger_with_custom_stream(self):
-        """Test get_logger with custom stream."""
-        custom_stream = StringIO()
-        logger = get_logger("stream_logger", stream=custom_stream)
-
-        assert isinstance(logger, logging.Logger)
-        # Logger should have a handler
-        assert len(logger.handlers) > 0
-
-    def test_get_logger_returns_same_logger_on_multiple_calls(self):
-        """Test that multiple calls return the same logger instance."""
-        logger1 = get_logger("same_logger")
-        logger2 = get_logger("same_logger")
-
-        assert logger1 is logger2
-
-    def test_get_logger_handler_configured(self):
-        """Test that logger has properly configured handler."""
-        logger = get_logger("handler_test")
-
-        assert len(logger.handlers) > 0
-        handler = logger.handlers[0]
-        assert isinstance(handler, logging.StreamHandler)
-        assert handler.level == logging.INFO
-
-    def test_get_logger_formatter_configured(self):
-        """Test that logger handler has formatter."""
-        logger = get_logger("formatter_test")
-
-        assert len(logger.handlers) > 0
-        handler = logger.handlers[0]
-        assert handler.formatter is not None
-
-    def test_get_logger_prevents_propagation(self):
-        """Test that logger doesn't propagate to root logger."""
-        logger = get_logger("no_propagation_test")
-
-        assert logger.propagate is False
-
-    def test_get_logger_with_info_level(self):
-        """Test get_logger with INFO level."""
-        logger = get_logger("info_logger", level=logging.INFO)
-
-        assert logger.level == logging.INFO
-
-    def test_get_logger_with_error_level(self):
-        """Test get_logger with ERROR level."""
-        logger = get_logger("error_logger", level=logging.ERROR)
-
-        assert logger.level == logging.ERROR
-
-    def test_get_logger_with_warning_level(self):
-        """Test get_logger with WARNING level."""
-        logger = get_logger("warning_logger", level=logging.WARNING)
-
-        assert logger.level == logging.WARNING
-
-
-class TestSetupCLILogging:
-    """Test setup_cli_logging function."""
-
-    def teardown_method(self):
-        """Clean up loggers after each test."""
-        root_logger = logging.getLogger("agentflowcli")
-        for handler in root_logger.handlers[:]:
-            root_logger.removeHandler(handler)
-
-    def test_setup_cli_logging_default(self):
-        """Test setup_cli_logging with default parameters."""
-        setup_cli_logging()
-
-        root_logger = logging.getLogger("agentflowcli")
-        assert root_logger.level == logging.INFO
-        assert len(root_logger.handlers) > 0
-
-    def test_setup_cli_logging_with_quiet(self):
-        """Test setup_cli_logging with quiet mode."""
-        setup_cli_logging(quiet=True)
-
-        root_logger = logging.getLogger("agentflowcli")
-        assert root_logger.level == logging.ERROR
-
-    def test_setup_cli_logging_with_verbose(self):
-        """Test setup_cli_logging with verbose mode."""
-        setup_cli_logging(verbose=True)
-
-        root_logger = logging.getLogger("agentflowcli")
-        assert root_logger.level == logging.DEBUG
-
-    def test_setup_cli_logging_quiet_overrides_verbose(self):
-        """Test that quiet mode takes precedence over verbose."""
-        setup_cli_logging(quiet=True, verbose=True)
-
-        root_logger = logging.getLogger("agentflowcli")
-        assert root_logger.level == logging.ERROR
-
-    def test_setup_cli_logging_with_custom_level(self):
-        """Test setup_cli_logging with custom level."""
-        setup_cli_logging(level=logging.WARNING)
-
-        root_logger = logging.getLogger("agentflowcli")
-        assert root_logger.level == logging.WARNING
-
-    def test_setup_cli_logging_removes_existing_handlers(self):
-        """Test that setup_cli_logging removes existing handlers."""
-        root_logger = logging.getLogger("agentflowcli")
-
-        # Add a dummy handler
-        dummy_handler = logging.StreamHandler()
-        root_logger.addHandler(dummy_handler)
-
-        initial_count = len(root_logger.handlers)
-
-        # Setup logging - should remove old handler
-        setup_cli_logging()
-
-        # Should have exactly one handler after setup
-        assert len(root_logger.handlers) == 1
-        assert dummy_handler not in root_logger.handlers
-
-    def test_setup_cli_logging_handler_configured(self):
-        """Test that handler is properly configured."""
-        setup_cli_logging(level=logging.DEBUG)
-
-        root_logger = logging.getLogger("agentflowcli")
-        handler = root_logger.handlers[0]
-
-        assert isinstance(handler, logging.StreamHandler)
-        assert handler.level == logging.DEBUG
-
-    def test_setup_cli_logging_prevents_propagation(self):
-        """Test that root logger doesn't propagate."""
-        setup_cli_logging()
-
-        root_logger = logging.getLogger("agentflowcli")
-        assert root_logger.propagate is False
-
-    def test_setup_cli_logging_verbose_debug_level(self):
-        """Test verbose mode sets DEBUG level."""
-        setup_cli_logging(verbose=True)
-
-        root_logger = logging.getLogger("agentflowcli")
-        assert root_logger.level == logging.DEBUG
-
-    def test_setup_cli_logging_quiet_error_level(self):
-        """Test quiet mode sets ERROR level."""
-        setup_cli_logging(quiet=True)
-
-        root_logger = logging.getLogger("agentflowcli")
-        assert root_logger.level == logging.ERROR
-
-
-class TestCreateDebugLogger:
-    """Test create_debug_logger function."""
-
-    def test_create_debug_logger_returns_logger(self):
-        """Test that create_debug_logger returns a Logger instance."""
-        logger = create_debug_logger("debug_test")
-
-        assert isinstance(logger, logging.Logger)
-
-    def test_create_debug_logger_sets_debug_level(self):
-        """Test that debug logger has DEBUG level."""
-        logger = create_debug_logger("debug_level_test")
-
-        assert logger.level == logging.DEBUG
-
-    def test_create_debug_logger_name_format(self):
-        """Test that debug logger has correct name format."""
-        logger = create_debug_logger("my_debug")
-
-        assert "my_debug" in logger.name
-        assert "agentflowcli" in logger.name
-
-    def test_create_debug_logger_has_handler(self):
-        """Test that debug logger has a handler."""
-        logger = create_debug_logger("debug_handler_test")
-
-        assert len(logger.handlers) > 0
-
-    def test_create_debug_logger_handler_is_stream_handler(self):
-        """Test that debug logger uses StreamHandler."""
-        logger = create_debug_logger("stream_handler_test")
-
-        handler = logger.handlers[0]
-        assert isinstance(handler, logging.StreamHandler)
-
-    def test_create_debug_logger_stderr_by_default(self):
-        """Test that debug logger uses stderr by default."""
-        logger = create_debug_logger("stderr_test")
-
-        handler = logger.handlers[0]
-        assert handler.stream == sys.stderr or handler.stream is None
-
-    def test_create_debug_logger_formatter_configured(self):
-        """Test that debug logger has formatter."""
-        logger = create_debug_logger("formatter_debug_test")
-
-        handler = logger.handlers[0]
-        assert handler.formatter is not None
-
-    def test_create_debug_logger_prevents_propagation(self):
-        """Test that debug logger doesn't propagate."""
-        logger = create_debug_logger("no_prop_debug_test")
-
-        assert logger.propagate is False
-
-
-class TestLoggerIntegration:
-    """Integration tests for logger functionality."""
-
-    def test_get_logger_and_setup_cli_logging_work_together(self):
-        """Test that get_logger works with setup_cli_logging."""
-        setup_cli_logging(verbose=True)
-
-        logger = get_logger("integration_test")
-
-        assert logger.level in (logging.DEBUG, logging.INFO)
-        assert len(logger.handlers) > 0
-
-    def test_multiple_loggers_independent(self):
-        """Test that multiple loggers can coexist."""
-        logger1 = get_logger("logger1", level=logging.INFO)
-        logger2 = get_logger("logger2", level=logging.DEBUG)
-
-        assert logger1.name != logger2.name
-        assert logger1.level == logging.INFO
-        assert logger2.level == logging.DEBUG
-
-    def test_cli_logger_mixin_with_setup(self):
-        """Test CLILoggerMixin with setup_cli_logging."""
-        setup_cli_logging(verbose=True)
-
-        class TestCmd(CLILoggerMixin):
-            pass
-
-        cmd = TestCmd()
-        assert isinstance(cmd.logger, logging.Logger)
-        assert len(cmd.logger.handlers) > 0
+def teardown_function() -> None:
+    root = logging.getLogger("agentflowcli")
+    root.handlers.clear()
+
+
+def test_mixin_uses_named_child_logger() -> None:
+    class ExampleCommand(CLILoggerMixin):
+        pass
+
+    command = ExampleCommand()
+    assert command.logger.name == "agentflowcli.ExampleCommand"
+    assert command.logger.propagate is True
+    assert command.logger.handlers == []
+
+
+def test_children_share_single_root_handler() -> None:
+    setup_cli_logging(verbose=True)
+    first = get_logger("first")
+    second = get_logger("second")
+    root = logging.getLogger("agentflowcli")
+    assert len(root.handlers) == 1
+    assert first.handlers == []
+    assert second.handlers == []
+    assert first.getEffectiveLevel() == logging.DEBUG
+    assert second.getEffectiveLevel() == logging.DEBUG
+
+
+def test_quiet_and_verbose_levels() -> None:
+    setup_cli_logging(verbose=True)
+    assert logging.getLogger("agentflowcli").level == logging.DEBUG
+    setup_cli_logging(quiet=True, verbose=True)
+    assert logging.getLogger("agentflowcli").level == logging.ERROR
+
+
+def test_reconfiguration_replaces_handler() -> None:
+    setup_cli_logging()
+    original = logging.getLogger("agentflowcli").handlers[0]
+    setup_cli_logging(level=logging.WARNING)
+    root = logging.getLogger("agentflowcli")
+    assert len(root.handlers) == 1
+    assert root.handlers[0] is not original
+    assert root.handlers[0].level == logging.WARNING
+
+
+def test_custom_stream_is_isolated() -> None:
+    stream = StringIO()
+    logger = get_logger("captured", level=logging.WARNING, stream=stream)
+    logger.warning("visible")
+    assert "visible" in stream.getvalue()
+    assert logger.propagate is False
+    assert len(logger.handlers) == 1
+
+
+def test_debug_logger_enables_debug_globally() -> None:
+    logger = create_debug_logger("debug")
+    assert logger.getEffectiveLevel() == logging.DEBUG
+    assert logging.getLogger("agentflowcli").handlers[0].level == logging.DEBUG

--- a/tests/unit_tests/test_cli_output.py
+++ b/tests/unit_tests/test_cli_output.py
@@ -145,11 +145,11 @@ def test_forced_tty_header_uses_animation_renderer(monkeypatch) -> None:
         def isatty(self) -> bool:
             return True
 
-    calls: list[tuple[str, str | None, bool]] = []
+    calls: list[tuple[str, str | None, bool, bool]] = []
     monkeypatch.setattr(
         "agentflow_cli.cli.core.output.render_command_intro",
-        lambda _console, *, command, subtitle, unicode: calls.append(
-            (command, subtitle, unicode)
+        lambda _console, *, command, subtitle, unicode, persistent_screen: calls.append(
+            (command, subtitle, unicode, persistent_screen)
         ),
     )
     stream = TTYStream()
@@ -159,7 +159,40 @@ def test_forced_tty_header_uses_animation_renderer(monkeypatch) -> None:
         progress_mode=ProgressMode.TTY,
     )
     rendered.command_header("play", "Start the playground")
-    assert calls == [("play", "Start the playground", True)]
+    assert calls == [("play", "Start the playground", True, False)]
+
+
+def test_fullscreen_session_owns_and_restores_alternate_screen(monkeypatch) -> None:
+    class FakeScreen:
+        entered = False
+        exited = False
+
+        def __enter__(self):
+            self.entered = True
+            return self
+
+        def __exit__(self, *_args):
+            self.exited = True
+
+    class FakeConsole:
+        def __init__(self) -> None:
+            self.context = FakeScreen()
+
+        def screen(self, **_kwargs):
+            return self.context
+
+    rendered, _stream = formatter(progress_mode=ProgressMode.TTY)
+    console = FakeConsole()
+    monkeypatch.setattr(rendered, "_console", lambda **_kwargs: console)
+
+    assert rendered.start_fullscreen_session() is True
+    assert rendered.fullscreen_active is True
+    assert console.context.entered is True
+    assert rendered.start_fullscreen_session() is False
+
+    rendered.end_fullscreen_session()
+    assert rendered.fullscreen_active is False
+    assert console.context.exited is True
 
 
 def test_structured_activity_emits_lifecycle_events() -> None:

--- a/tests/unit_tests/test_cli_output.py
+++ b/tests/unit_tests/test_cli_output.py
@@ -1,11 +1,12 @@
-"""Tests for CLI output formatting module."""
+"""Behavioral tests for adaptive CLI output."""
+
+from __future__ import annotations
 
 import io
+import json
 import sys
-from unittest.mock import patch
 
-import pytest
-
+from agentflow_cli.cli.capabilities import ColorMode, OutputFormat, ProgressMode
 from agentflow_cli.cli.core.output import (
     OutputFormatter,
     emphasize,
@@ -18,354 +19,142 @@ from agentflow_cli.cli.core.output import (
 )
 
 
-class TestOutputFormatter:
-    """Test suite for OutputFormatter class."""
-
-    @pytest.fixture
-    def output_stream(self):
-        """Create a string buffer for capturing output."""
-        return io.StringIO()
-
-    @pytest.fixture
-    def formatter(self, output_stream):
-        """Create an OutputFormatter instance with test stream."""
-        return OutputFormatter(stream=output_stream)
-
-    def test_initialization_default_stream(self):
-        """Test OutputFormatter initialization with default stream."""
-        formatter = OutputFormatter()
-        assert formatter.stream == sys.stdout
-
-    def test_initialization_custom_stream(self, output_stream):
-        """Test OutputFormatter initialization with custom stream."""
-        formatter = OutputFormatter(stream=output_stream)
-        assert formatter.stream == output_stream
-
-    @patch("typer.echo")
-    def test_print_banner_with_title_only(self, mock_echo, formatter):
-        """Test printing banner with only title."""
-        formatter.print_banner("Test Title")
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-        # Should print banner with title
-
-    @patch("typer.echo")
-    def test_print_banner_with_subtitle(self, mock_echo, formatter):
-        """Test printing banner with title and subtitle."""
-        formatter.print_banner("Test Title", subtitle="Test Subtitle")
-
-        # Verify typer.echo was called multiple times (for empty line, title, subtitle, empty line)
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_banner_with_color(self, mock_echo, formatter):
-        """Test printing banner with custom color."""
-        formatter.print_banner("Test Title", color="green")
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_banner_with_width(self, mock_echo, formatter):
-        """Test printing banner with custom width."""
-        formatter.print_banner("Test Title", width=100)
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_success_message_with_emoji(self, mock_echo, formatter):
-        """Test printing success message with emoji."""
-        formatter.success("Operation successful")
-
-        # Verify typer.echo was called with success styling
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_success_message_without_emoji(self, mock_echo, formatter):
-        """Test printing success message without emoji."""
-        formatter.success("Operation successful", emoji=False)
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_error_message_with_emoji(self, mock_echo, formatter):
-        """Test printing error message with emoji."""
-        formatter.error("An error occurred")
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_error_message_without_emoji(self, mock_echo, formatter):
-        """Test printing error message without emoji."""
-        formatter.error("An error occurred", emoji=False)
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_info_message_with_emoji(self, mock_echo, formatter):
-        """Test printing info message with emoji."""
-        formatter.info("Information message")
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_info_message_without_emoji(self, mock_echo, formatter):
-        """Test printing info message without emoji."""
-        formatter.info("Information message", emoji=False)
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_warning_message_with_emoji(self, mock_echo, formatter):
-        """Test printing warning message with emoji."""
-        formatter.warning("Warning message")
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_warning_message_without_emoji(self, mock_echo, formatter):
-        """Test printing warning message without emoji."""
-        formatter.warning("Warning message", emoji=False)
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_emphasize_message(self, mock_echo, formatter):
-        """Test printing emphasized message."""
-        formatter.emphasize("Important message")
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_list_without_title(self, mock_echo, formatter):
-        """Test printing list without title."""
-        items = ["Item 1", "Item 2", "Item 3"]
-        formatter.print_list(items)
-
-        # Verify typer.echo was called for each item
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_list_with_title(self, mock_echo, formatter):
-        """Test printing list with title."""
-        items = ["Item 1", "Item 2", "Item 3"]
-        formatter.print_list(items, title="My List")
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_list_with_custom_bullet(self, mock_echo, formatter):
-        """Test printing list with custom bullet character."""
-        items = ["Item 1", "Item 2", "Item 3"]
-        formatter.print_list(items, bullet="-")
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_list_empty(self, mock_echo, formatter):
-        """Test printing empty list."""
-        formatter.print_list([])
-
-        # With an empty list and no title, typer.echo might not be called at all
-        # or may be called for the empty list display. Both are acceptable.
-        # Just verify the method doesn't raise an exception
-
-    @patch("typer.echo")
-    def test_print_key_value_pairs_without_title(self, mock_echo, formatter):
-        """Test printing key-value pairs without title."""
-        pairs = {"name": "John", "age": 30, "city": "New York"}
-        formatter.print_key_value_pairs(pairs)
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_key_value_pairs_with_title(self, mock_echo, formatter):
-        """Test printing key-value pairs with title."""
-        pairs = {"name": "John", "age": 30, "city": "New York"}
-        formatter.print_key_value_pairs(pairs, title="User Info")
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_key_value_pairs_custom_indent(self, mock_echo, formatter):
-        """Test printing key-value pairs with custom indentation."""
-        pairs = {"key1": "value1", "key2": "value2"}
-        formatter.print_key_value_pairs(pairs, indent=4)
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_table_without_title(self, mock_echo, formatter):
-        """Test printing table without title."""
-        headers = ["Name", "Age", "City"]
-        rows = [
-            ["John", "30", "New York"],
-            ["Jane", "28", "Los Angeles"],
-            ["Bob", "35", "Chicago"],
-        ]
-        formatter.print_table(headers, rows)
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_table_with_title(self, mock_echo, formatter):
-        """Test printing table with title."""
-        headers = ["Name", "Age", "City"]
-        rows = [
-            ["John", "30", "New York"],
-            ["Jane", "28", "Los Angeles"],
-        ]
-        formatter.print_table(headers, rows, title="People")
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_table_empty(self, mock_echo, formatter):
-        """Test printing table with no rows."""
-        headers = ["Name", "Age", "City"]
-        rows = []
-        formatter.print_table(headers, rows)
-
-        # Verify typer.echo was called
-        assert mock_echo.called
-
-    @patch("typer.echo")
-    def test_print_table_inconsistent_row_length(self, mock_echo, formatter):
-        """Test printing table with rows of inconsistent length."""
-        headers = ["Name", "Age", "City"]
-        rows = [
-            ["John", "30"],  # Missing City
-            ["Jane", "28", "Los Angeles"],
-            ["Bob", "35", "Chicago", "Extra"],  # Extra column
-        ]
-        formatter.print_table(headers, rows)
-
-        # Should handle inconsistent row lengths gracefully
-        assert mock_echo.called
-
-
-class TestGlobalFunctions:
-    """Test suite for global convenience functions."""
-
-    @patch("agentflow_cli.cli.core.output.output.print_banner")
-    def test_print_banner_function(self, mock_print_banner):
-        """Test global print_banner function."""
-        print_banner("Test Title")
-
-        # Verify the method was called on the global instance
-        assert mock_print_banner.called
-
-    @patch("agentflow_cli.cli.core.output.output.success")
-    def test_success_function(self, mock_success):
-        """Test global success function."""
-        success("Operation successful")
-
-        # Verify the method was called on the global instance
-        assert mock_success.called
-
-    @patch("agentflow_cli.cli.core.output.output.error")
-    def test_error_function(self, mock_error):
-        """Test global error function."""
-        error("An error occurred")
-
-        # Verify the method was called on the global instance
-        assert mock_error.called
-
-    @patch("agentflow_cli.cli.core.output.output.info")
-    def test_info_function(self, mock_info):
-        """Test global info function."""
-        info("Information message")
-
-        # Verify the method was called on the global instance
-        assert mock_info.called
-
-    @patch("agentflow_cli.cli.core.output.output.warning")
-    def test_warning_function(self, mock_warning):
-        """Test global warning function."""
-        warning("Warning message")
-
-        # Verify the method was called on the global instance
-        assert mock_warning.called
-
-    @patch("agentflow_cli.cli.core.output.output.emphasize")
-    def test_emphasize_function(self, mock_emphasize):
-        """Test global emphasize function."""
-        emphasize("Important message")
-
-        # Verify the method was called on the global instance
-        assert mock_emphasize.called
-
-
-class TestOutputFormatterIntegration:
-    """Integration tests for OutputFormatter."""
-
-    def test_multiple_messages_sequence(self):
-        """Test printing multiple messages in sequence."""
-        stream = io.StringIO()
-        formatter = OutputFormatter(stream=stream)
-
-        with patch("typer.echo") as mock_echo:
-            formatter.info("Starting process")
-            formatter.success("Step 1 complete")
-            formatter.warning("Step 2 warning")
-            formatter.error("Step 3 error")
-
-            # All should have been called
-            assert mock_echo.call_count >= 4
-
-    def test_complex_table_output(self):
-        """Test printing a complex table."""
-        stream = io.StringIO()
-        formatter = OutputFormatter(stream=stream)
-
-        headers = ["ID", "Status", "Message"]
-        rows = [
-            ["1", "SUCCESS", "Operation completed"],
-            ["2", "FAILED", "Error occurred"],
-            ["3", "PENDING", "Waiting for response"],
-        ]
-
-        with patch("typer.echo") as mock_echo:
-            formatter.print_table(headers, rows, title="Operation Status")
-            assert mock_echo.called
-
-    def test_global_instance_exists(self):
-        """Test that global output instance exists."""
-        assert output is not None
-        assert isinstance(output, OutputFormatter)
-
-    def test_formatter_with_various_data_types(self):
-        """Test formatter with various data types in key-value pairs."""
-        stream = io.StringIO()
-        formatter = OutputFormatter(stream=stream)
-
-        pairs = {
-            "string": "hello",
-            "integer": 42,
-            "float": 3.14,
-            "boolean": True,
-            "none": None,
-            "list": [1, 2, 3],
-        }
-
-        with patch("typer.echo") as mock_echo:
-            formatter.print_key_value_pairs(pairs)
-            # Should handle all data types
-            assert mock_echo.called
+def formatter(**kwargs) -> tuple[OutputFormatter, io.StringIO]:
+    stream = io.StringIO()
+    return OutputFormatter(stream=stream, **kwargs), stream
+
+
+def test_initialization_default_and_custom_stream() -> None:
+    assert OutputFormatter().stream == sys.stdout
+    custom = io.StringIO()
+    assert OutputFormatter(stream=custom).stream is custom
+
+
+def test_plain_banner_contains_title_and_subtitle() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.PLAIN)
+    rendered.print_banner("Test Title", "Test Subtitle", width=100)
+    value = stream.getvalue()
+    assert "== Test Title ==" in value
+    assert "Test Subtitle" in value
+
+
+def test_semantic_messages_render_visible_text_and_symbols() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.PLAIN)
+    rendered.success("Operation successful")
+    rendered.error("An error occurred")
+    rendered.info("Information message")
+    rendered.warning("Warning message")
+    rendered.emphasize("Important message")
+    value = stream.getvalue()
+    for expected in (
+        "Operation successful",
+        "An error occurred",
+        "Information message",
+        "Warning message",
+        "Important message",
+    ):
+        assert expected in value
+
+
+def test_messages_can_omit_symbols() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.PLAIN)
+    rendered.success("success", emoji=False)
+    rendered.error("error", emoji=False)
+    rendered.info("info", emoji=False)
+    rendered.warning("warning", emoji=False)
+    assert stream.getvalue().splitlines() == ["success", "error", "info", "warning"]
+
+
+def test_list_key_values_and_table_render_content() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.PLAIN)
+    rendered.print_list(["one", "two"], title="Items", bullet="-")
+    rendered.print_key_value_pairs({"name": "Ada", "age": 30}, title="Person", indent=4)
+    rendered.print_table(
+        ["Name", "Age", "City"],
+        [["Ada", "30"], ["Grace", "28", "New York", "ignored"]],
+        title="People",
+    )
+    value = stream.getvalue()
+    for expected in ("Items", "one", "two", "Person", "Ada", "30", "People", "New York"):
+        assert expected in value
+
+
+def test_empty_list_and_table_do_not_fail() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.PLAIN)
+    rendered.print_list([])
+    rendered.print_table(["Name"], [])
+    assert "Name" in stream.getvalue()
+
+
+def test_jsonl_messages_are_versioned_objects() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.JSONL)
+    rendered.success("done")
+    rendered.print_table(["name"], [["agent"]], title="Agents")
+    payloads = [json.loads(line) for line in stream.getvalue().splitlines()]
+    assert payloads[0] == {
+        "schema": "agentflow.cli/v1",
+        "type": "success",
+        "message": "done",
+    }
+    assert payloads[1]["type"] == "table"
+    assert payloads[1]["rows"] == [{"name": "agent"}]
+
+
+def test_quiet_suppresses_non_error_output() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.PLAIN, quiet=True)
+    rendered.print_banner("hidden")
+    rendered.success("hidden")
+    rendered.info("hidden")
+    rendered.warning("hidden")
+    rendered.print_list(["hidden"])
+    rendered.error("visible", emoji=False)
+    assert stream.getvalue() == "visible\n"
+
+
+def test_no_color_produces_no_ansi_sequences() -> None:
+    rendered, stream = formatter(
+        output_format=OutputFormat.HUMAN,
+        color_mode=ColorMode.NEVER,
+    )
+    rendered.success("done")
+    assert "\x1b[" not in stream.getvalue()
+
+
+def test_plain_status_degrades_to_a_checkpoint() -> None:
+    rendered, stream = formatter(
+        output_format=OutputFormat.PLAIN,
+        progress_mode=ProgressMode.PLAIN,
+    )
+    with rendered.status("Loading"):
+        pass
+    assert "Loading" in stream.getvalue()
+
+
+def test_global_convenience_functions_delegate(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(output, "print_banner", lambda value, *a, **k: calls.append(("banner", value)))
+    monkeypatch.setattr(output, "success", lambda value, *a, **k: calls.append(("success", value)))
+    monkeypatch.setattr(output, "error", lambda value, *a, **k: calls.append(("error", value)))
+    monkeypatch.setattr(output, "info", lambda value, *a, **k: calls.append(("info", value)))
+    monkeypatch.setattr(output, "warning", lambda value, *a, **k: calls.append(("warning", value)))
+    monkeypatch.setattr(output, "emphasize", lambda value: calls.append(("emphasize", value)))
+
+    print_banner("a")
+    success("b")
+    error("c")
+    info("d")
+    warning("e")
+    emphasize("f")
+
+    assert calls == [
+        ("banner", "a"),
+        ("success", "b"),
+        ("error", "c"),
+        ("info", "d"),
+        ("warning", "e"),
+        ("emphasize", "f"),
+    ]
+
+
+def test_global_instance_exists() -> None:
+    assert isinstance(output, OutputFormatter)

--- a/tests/unit_tests/test_cli_output.py
+++ b/tests/unit_tests/test_cli_output.py
@@ -163,23 +163,23 @@ def test_forced_tty_header_uses_animation_renderer(monkeypatch) -> None:
 
 
 def test_fullscreen_session_owns_and_restores_alternate_screen(monkeypatch) -> None:
-    class FakeScreen:
-        entered = False
-        exited = False
-
-        def __enter__(self):
-            self.entered = True
-            return self
-
-        def __exit__(self, *_args):
-            self.exited = True
-
     class FakeConsole:
-        def __init__(self) -> None:
-            self.context = FakeScreen()
+        is_terminal = True
+        width = 80
 
-        def screen(self, **_kwargs):
-            return self.context
+        def __init__(self) -> None:
+            self.file = io.StringIO()
+            self.alt_screen_calls: list[bool] = []
+            self.cursor_shown: list[bool] = []
+
+        def set_alt_screen(self, enable: bool) -> None:
+            self.alt_screen_calls.append(enable)
+
+        def show_cursor(self, show: bool) -> None:
+            self.cursor_shown.append(show)
+
+        def print(self, *_args, **_kwargs) -> None:
+            return None
 
     rendered, _stream = formatter(progress_mode=ProgressMode.TTY)
     console = FakeConsole()
@@ -187,12 +187,110 @@ def test_fullscreen_session_owns_and_restores_alternate_screen(monkeypatch) -> N
 
     assert rendered.start_fullscreen_session() is True
     assert rendered.fullscreen_active is True
-    assert console.context.entered is True
+    assert console.alt_screen_calls == [True]
+    # A second call must not stack a nested screen on the first.
     assert rendered.start_fullscreen_session() is False
 
     rendered.end_fullscreen_session()
     assert rendered.fullscreen_active is False
-    assert console.context.exited is True
+    assert console.alt_screen_calls == [True, False]
+    assert console.cursor_shown == [True]
+
+
+def test_fullscreen_session_is_skipped_off_a_terminal(monkeypatch) -> None:
+    class NonTerminalConsole:
+        is_terminal = False
+
+    rendered, _stream = formatter(progress_mode=ProgressMode.TTY)
+    monkeypatch.setattr(rendered, "_console", lambda **_kwargs: NonTerminalConsole())
+
+    assert rendered.start_fullscreen_session() is False
+    assert rendered.fullscreen_active is False
+
+
+def test_timeline_and_progress_pick_the_renderer_for_the_output_mode() -> None:
+    from agentflow_cli.cli.core.steps import (
+        LiveProgressRun,
+        LiveTimeline,
+        QuietProgressRun,
+        QuietTimeline,
+        StaticProgressRun,
+        StaticTimeline,
+        StructuredProgressRun,
+        StructuredTimeline,
+    )
+
+    quiet, _ = formatter(quiet=True)
+    assert isinstance(quiet.timeline("t"), QuietTimeline)
+    assert isinstance(quiet.progress_run("p", total=1), QuietProgressRun)
+
+    structured, _ = formatter(output_format=OutputFormat.JSONL)
+    assert isinstance(structured.timeline("t"), StructuredTimeline)
+    assert isinstance(structured.progress_run("p", total=1), StructuredProgressRun)
+
+    plain, _ = formatter(output_format=OutputFormat.PLAIN, progress_mode=ProgressMode.PLAIN)
+    assert isinstance(plain.timeline("t"), StaticTimeline)
+    assert isinstance(plain.progress_run("p", total=1), StaticProgressRun)
+
+    animated, _ = formatter(progress_mode=ProgressMode.TTY)
+    assert isinstance(animated.timeline("t"), LiveTimeline)
+    assert isinstance(animated.progress_run("p", total=1), LiveProgressRun)
+
+
+def test_plain_timeline_reports_every_stage_transition() -> None:
+    rendered, stream = formatter(
+        output_format=OutputFormat.PLAIN,
+        progress_mode=ProgressMode.PLAIN,
+    )
+    timeline = rendered.timeline("Working", steps=(("a", "First stage"),))
+    with timeline, timeline.step("a") as step:
+        step.detail("all good")
+
+    value = stream.getvalue()
+    assert "Working" in value
+    assert value.count("First stage") == 2
+    assert "all good" in value
+
+
+def test_structured_timeline_stays_valid_json_per_line() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.JSONL)
+    timeline = rendered.timeline("Working", steps=(("a", "First stage"),))
+    with timeline, timeline.step("a"):
+        pass
+
+    payloads = [json.loads(line) for line in stream.getvalue().splitlines()]
+    assert [payload["type"] for payload in payloads] == [
+        "timeline_start",
+        "step_start",
+        "step_end",
+        "timeline_end",
+    ]
+    assert all(payload["schema"] == "agentflow.cli/v1" for payload in payloads)
+
+
+def test_quiet_timeline_writes_nothing() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.PLAIN, quiet=True)
+    timeline = rendered.timeline("Working", steps=(("a", "First stage"),))
+    with timeline, timeline.step("a") as step:
+        step.detail("hidden")
+    assert stream.getvalue() == ""
+
+
+def test_completion_screen_reveals_rows_progressively() -> None:
+    rendered, _stream = formatter()
+    rows = [("API", "http://localhost:8000"), ("Config", "agentflow.json")]
+    steps = ["Open the docs"]
+
+    first = rendered._completion_panel("Ready", "All set", rows, steps, 0)
+    assert "API" not in first.renderable.plain
+
+    partial = rendered._completion_panel("Ready", "All set", rows, steps, 1)
+    assert "API" in partial.renderable.plain
+    assert "Config" not in partial.renderable.plain
+
+    full = rendered._completion_panel("Ready", "All set", rows, steps, len(rows) + len(steps))
+    assert "Config" in full.renderable.plain
+    assert "Open the docs" in full.renderable.plain
 
 
 def test_structured_activity_emits_lifecycle_events() -> None:
@@ -224,7 +322,9 @@ def test_structured_completion_screen_is_one_event() -> None:
 
 def test_global_convenience_functions_delegate(monkeypatch) -> None:
     calls: list[tuple[str, str]] = []
-    monkeypatch.setattr(output, "print_banner", lambda value, *a, **k: calls.append(("banner", value)))
+    monkeypatch.setattr(
+        output, "print_banner", lambda value, *a, **k: calls.append(("banner", value))
+    )
     monkeypatch.setattr(output, "success", lambda value, *a, **k: calls.append(("success", value)))
     monkeypatch.setattr(output, "error", lambda value, *a, **k: calls.append(("error", value)))
     monkeypatch.setattr(output, "info", lambda value, *a, **k: calls.append(("info", value)))

--- a/tests/unit_tests/test_cli_output.py
+++ b/tests/unit_tests/test_cli_output.py
@@ -162,26 +162,34 @@ def test_forced_tty_header_uses_animation_renderer(monkeypatch) -> None:
     assert calls == [("play", "Start the playground", True, False)]
 
 
+class FakeConsole:
+    """Minimal console double that records the terminal control it receives."""
+
+    is_terminal = True
+    width = 100
+    height = 30
+
+    def __init__(self) -> None:
+        self.file = io.StringIO()
+        self.alt_screen_calls: list[bool] = []
+        self.cursor_shown: list[bool] = []
+
+    # Mirrors Rich: True when the alternate buffer was actually entered.
+    alt_screen_supported = True
+
+    def set_alt_screen(self, enable: bool) -> bool:
+        self.alt_screen_calls.append(enable)
+        return self.alt_screen_supported
+
+    def show_cursor(self, show: bool) -> None:
+        self.cursor_shown.append(show)
+
+    def print(self, *_args, **_kwargs) -> None:
+        return None
+
+
 def test_fullscreen_session_owns_and_restores_alternate_screen(monkeypatch) -> None:
-    class FakeConsole:
-        is_terminal = True
-        width = 80
-
-        def __init__(self) -> None:
-            self.file = io.StringIO()
-            self.alt_screen_calls: list[bool] = []
-            self.cursor_shown: list[bool] = []
-
-        def set_alt_screen(self, enable: bool) -> None:
-            self.alt_screen_calls.append(enable)
-
-        def show_cursor(self, show: bool) -> None:
-            self.cursor_shown.append(show)
-
-        def print(self, *_args, **_kwargs) -> None:
-            return None
-
-    rendered, _stream = formatter(progress_mode=ProgressMode.TTY)
+    rendered, _stream = formatter(progress_mode=ProgressMode.TTY, color_mode=ColorMode.ALWAYS)
     console = FakeConsole()
     monkeypatch.setattr(rendered, "_console", lambda **_kwargs: console)
 
@@ -195,10 +203,12 @@ def test_fullscreen_session_owns_and_restores_alternate_screen(monkeypatch) -> N
     assert rendered.fullscreen_active is False
     assert console.alt_screen_calls == [True, False]
     assert console.cursor_shown == [True]
+    # The scrolling region must be released, or the user's shell inherits it.
+    assert "\x1b[r" in console.file.getvalue()
 
 
 def test_fullscreen_session_is_skipped_off_a_terminal(monkeypatch) -> None:
-    class NonTerminalConsole:
+    class NonTerminalConsole(FakeConsole):
         is_terminal = False
 
     rendered, _stream = formatter(progress_mode=ProgressMode.TTY)
@@ -206,6 +216,115 @@ def test_fullscreen_session_is_skipped_off_a_terminal(monkeypatch) -> None:
 
     assert rendered.start_fullscreen_session() is False
     assert rendered.fullscreen_active is False
+
+
+def test_fullscreen_session_is_skipped_on_a_terminal_too_short_for_chrome(monkeypatch) -> None:
+    class ShortConsole(FakeConsole):
+        height = 8
+
+    rendered, _stream = formatter(progress_mode=ProgressMode.TTY, color_mode=ColorMode.ALWAYS)
+    monkeypatch.setattr(rendered, "_console", lambda **_kwargs: ShortConsole())
+
+    assert rendered.start_fullscreen_session() is False
+
+
+def test_fullscreen_session_writes_nothing_when_the_console_refuses(monkeypatch) -> None:
+    """A legacy console claims to be a terminal but rejects the alternate buffer.
+
+    Painting anyway would leave a scrolling region on the user's real scrollback,
+    which outlives the process.
+    """
+
+    class RefusingConsole(FakeConsole):
+        alt_screen_supported = False
+
+    rendered, _stream = formatter(progress_mode=ProgressMode.TTY, color_mode=ColorMode.ALWAYS)
+    console = RefusingConsole()
+    monkeypatch.setattr(rendered, "_console", lambda **_kwargs: console)
+
+    assert rendered.start_fullscreen_session() is False
+    assert rendered.fullscreen_active is False
+    assert console.file.getvalue() == ""
+
+
+class TTYStream(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+def tty_formatter() -> OutputFormatter:
+    """A formatter that stays in human mode, as it would on a real terminal."""
+    return OutputFormatter(
+        stream=TTYStream(),
+        progress_mode=ProgressMode.TTY,
+        color_mode=ColorMode.ALWAYS,
+    )
+
+
+def test_requesting_fullscreen_does_not_claim_the_screen_on_its_own(monkeypatch) -> None:
+    """Script-shaped commands print and exit without ever taking the terminal."""
+    rendered = tty_formatter()
+    console = FakeConsole()
+    monkeypatch.setattr(rendered, "_console", lambda **_kwargs: console)
+
+    rendered.request_fullscreen(True)
+    rendered.success("done")
+
+    assert rendered.fullscreen_active is False
+    assert console.alt_screen_calls == []
+    # Closing without a session must stay a no-op, including the Enter pause.
+    rendered.end_fullscreen_session()
+    assert console.alt_screen_calls == []
+
+
+def test_command_header_claims_the_screen_when_fullscreen_was_requested(monkeypatch) -> None:
+    rendered = tty_formatter()
+    console = FakeConsole()
+    monkeypatch.setattr(rendered, "_console", lambda **_kwargs: console)
+    monkeypatch.setattr(
+        "agentflow_cli.cli.core.output.render_command_intro",
+        lambda *_args, **_kwargs: None,
+    )
+
+    rendered.request_fullscreen(True)
+    rendered.command_header("play", "Serve it")
+    assert rendered.fullscreen_active is True
+    assert console.alt_screen_calls == [True]
+
+
+def test_command_header_stays_in_the_normal_buffer_without_fullscreen(monkeypatch) -> None:
+    rendered = tty_formatter()
+    console = FakeConsole()
+    monkeypatch.setattr(rendered, "_console", lambda **_kwargs: console)
+    monkeypatch.setattr(
+        "agentflow_cli.cli.core.output.render_command_intro",
+        lambda *_args, **_kwargs: None,
+    )
+
+    rendered.request_fullscreen(False)
+    rendered.command_header("play", "Serve it")
+    assert rendered.fullscreen_active is False
+    assert console.alt_screen_calls == []
+
+
+def test_command_header_pins_chrome_inside_a_fullscreen_session(monkeypatch) -> None:
+    # A real TTY stream, so the formatter stays in human mode and reaches the frame.
+    rendered = tty_formatter()
+    console = FakeConsole()
+    monkeypatch.setattr(rendered, "_console", lambda **_kwargs: console)
+    monkeypatch.setattr(
+        "agentflow_cli.cli.core.output.render_command_intro",
+        lambda *_args, **_kwargs: None,
+    )
+
+    assert rendered.start_fullscreen_session() is True
+    rendered.command_header("play", "Serve it", hint="Ctrl+C to stop")
+
+    written = console.file.getvalue()
+    # Header, footer, and a scrolling region confining output between them.
+    assert "play" in written
+    assert "Ctrl+C to stop" in written
+    assert f"\x1b[5;{console.height - 2}r" in written
 
 
 def test_timeline_and_progress_pick_the_renderer_for_the_output_mode() -> None:

--- a/tests/unit_tests/test_cli_output.py
+++ b/tests/unit_tests/test_cli_output.py
@@ -130,6 +130,65 @@ def test_plain_status_degrades_to_a_checkpoint() -> None:
     assert "Loading" in stream.getvalue()
 
 
+def test_plain_command_header_degrades_to_static_banner() -> None:
+    rendered, stream = formatter(
+        output_format=OutputFormat.PLAIN,
+        progress_mode=ProgressMode.PLAIN,
+    )
+    rendered.command_header("play", "Start the playground")
+    assert "== Play ==" in stream.getvalue()
+    assert "Start the playground" in stream.getvalue()
+
+
+def test_forced_tty_header_uses_animation_renderer(monkeypatch) -> None:
+    class TTYStream(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    calls: list[tuple[str, str | None, bool]] = []
+    monkeypatch.setattr(
+        "agentflow_cli.cli.core.output.render_command_intro",
+        lambda _console, *, command, subtitle, unicode: calls.append(
+            (command, subtitle, unicode)
+        ),
+    )
+    stream = TTYStream()
+    rendered = OutputFormatter(
+        stream=stream,
+        output_format=OutputFormat.HUMAN,
+        progress_mode=ProgressMode.TTY,
+    )
+    rendered.command_header("play", "Start the playground")
+    assert calls == [("play", "Start the playground", True)]
+
+
+def test_structured_activity_emits_lifecycle_events() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.JSONL)
+    with rendered.activity("Loading graph", done="Graph loaded"):
+        pass
+    payloads = [json.loads(line) for line in stream.getvalue().splitlines()]
+    assert [payload["type"] for payload in payloads] == [
+        "progress_start",
+        "progress_end",
+        "success",
+    ]
+    assert payloads[1]["status"] == "completed"
+
+
+def test_structured_completion_screen_is_one_event() -> None:
+    rendered, stream = formatter(output_format=OutputFormat.JSONL)
+    rendered.completion_screen(
+        "Ready",
+        "Server configured",
+        details={"API": "http://localhost:8000"},
+        next_steps=["Open docs"],
+    )
+    payload = json.loads(stream.getvalue())
+    assert payload["type"] == "completion"
+    assert payload["title"] == "Ready"
+    assert payload["details"]["API"] == "http://localhost:8000"
+
+
 def test_global_convenience_functions_delegate(monkeypatch) -> None:
     calls: list[tuple[str, str]] = []
     monkeypatch.setattr(output, "print_banner", lambda value, *a, **k: calls.append(("banner", value)))

--- a/tests/unit_tests/test_cli_prompts.py
+++ b/tests/unit_tests/test_cli_prompts.py
@@ -1,0 +1,233 @@
+"""Tests for the shared guided-prompt service."""
+
+from __future__ import annotations
+
+import pytest
+import questionary
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+
+import agentflow_cli.cli.core.prompts as prompts_module
+from agentflow_cli.cli.core.prompts import (
+    MULTI_SELECT_HINT,
+    PROMPT_STYLE,
+    Choice,
+    PromptService,
+)
+from agentflow_cli.cli.exceptions import ValidationError
+
+
+class _StubQuestion:
+    """Stands in for a questionary Question without touching the terminal."""
+
+    def __init__(self, answer: object = None, raises: Exception | None = None) -> None:
+        self.answer = answer
+        self.raises = raises
+
+    def ask(self) -> object:
+        if self.raises is not None:
+            raise self.raises
+        return self.answer
+
+
+# --- choice rendering -----------------------------------------------------
+
+
+def test_choice_keeps_description_visually_secondary() -> None:
+    rendered = Choice("codex", "Codex", ".agents/skills/agentflow").to_questionary()
+    assert rendered.value == "codex"
+    assert rendered.title == [
+        ("class:text", "Codex"),
+        ("class:instruction", "  .agents/skills/agentflow"),
+    ]
+
+
+def test_choice_without_description_is_title_only() -> None:
+    rendered = Choice("codex", "Codex").to_questionary()
+    assert rendered.title == [("class:text", "Codex")]
+
+
+def test_choice_carries_checked_and_disabled_state() -> None:
+    rendered = Choice("x", "X", checked=True, disabled="not supported here").to_questionary()
+    assert rendered.checked is True
+    assert rendered.disabled == "not supported here"
+
+
+# --- interactivity policy -------------------------------------------------
+
+
+def test_require_interactive_passes_when_a_user_is_present() -> None:
+    PromptService(interactive=True).require_interactive(field="agent", alternatives="Pass --agent.")
+
+
+def test_require_interactive_explains_the_flag_alternative() -> None:
+    service = PromptService(interactive=False)
+    with pytest.raises(ValidationError) as excinfo:
+        service.require_interactive(field="agent", alternatives="Pass --agent codex.")
+
+    message = str(excinfo.value)
+    assert "stdin is not interactive" in message
+    assert "Pass --agent codex." in message
+
+
+# --- chrome restoration ---------------------------------------------------
+
+
+def test_pinned_chrome_is_restored_after_every_answer(monkeypatch) -> None:
+    """Prompt-toolkit erases past a scrolling region, taking the footer with it."""
+    redraws: list[int] = []
+    service = PromptService(interactive=True, on_answered=lambda: redraws.append(1))
+    monkeypatch.setattr(questionary, "confirm", lambda *a, **k: _StubQuestion(True))
+
+    assert service.confirm("Overwrite?") is True
+    assert redraws == [1]
+
+
+def test_pinned_chrome_is_restored_even_when_a_prompt_raises(monkeypatch) -> None:
+    redraws: list[int] = []
+    service = PromptService(interactive=True, on_answered=lambda: redraws.append(1))
+    monkeypatch.setattr(
+        questionary,
+        "text",
+        lambda *a, **k: _StubQuestion(raises=RuntimeError("terminal lost")),
+    )
+
+    with pytest.raises(ValidationError):
+        service.text("Name?")
+    assert redraws == [1]
+
+
+def test_cancelling_a_prompt_returns_none(monkeypatch) -> None:
+    service = PromptService(interactive=True)
+    monkeypatch.setattr(questionary, "select", lambda *a, **k: _StubQuestion(None))
+    assert service.select("Pick", [Choice("a", "A")]) is None
+
+
+# --- terminals that cannot host a prompt ----------------------------------
+
+
+def test_a_tty_that_cannot_host_a_prompt_counts_as_non_interactive(monkeypatch) -> None:
+    """MSYS/Cygwin stdin reports as a TTY but prompt-toolkit cannot attach."""
+    monkeypatch.setattr(prompts_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(prompts_module, "prompt_toolkit_available", lambda: False)
+    assert PromptService().interactive is False
+
+
+def test_a_usable_tty_is_interactive(monkeypatch) -> None:
+    monkeypatch.setattr(prompts_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(prompts_module, "prompt_toolkit_available", lambda: True)
+    assert PromptService().interactive is True
+
+
+def test_availability_probe_reports_false_when_the_console_is_rejected(monkeypatch) -> None:
+    import prompt_toolkit.output.defaults as pt_output
+
+    def refuse() -> None:
+        raise RuntimeError("Found xterm-256color, while expecting a Windows console.")
+
+    monkeypatch.setattr(pt_output, "create_output", refuse)
+    assert prompts_module.prompt_toolkit_available() is False
+
+
+def test_a_terminal_failure_mid_prompt_is_a_usage_error_not_a_crash(monkeypatch) -> None:
+    """It must not surface as AF-INTERNAL-001; the user needs an actionable fix."""
+    service = PromptService(interactive=True)
+    monkeypatch.setattr(
+        questionary,
+        "checkbox",
+        lambda *a, **k: _StubQuestion(raises=RuntimeError("no console")),
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        service.checkbox("Which agents?", [Choice("a", "A")])
+    assert "command-line flag" in str(excinfo.value)
+
+
+# --- what the service hands to questionary --------------------------------
+
+
+def test_checkbox_ships_the_toggle_hint_and_shared_style(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def capture(message, **kwargs):
+        captured.update(kwargs, message=message)
+        return _StubQuestion(["a"])
+
+    monkeypatch.setattr(questionary, "checkbox", capture)
+    service = PromptService(interactive=True)
+    assert service.checkbox("Which agents?", [Choice("a", "A")]) == ["a"]
+
+    assert captured["message"] == "Which agents?"
+    assert captured["instruction"] == MULTI_SELECT_HINT
+    assert captured["style"] is PROMPT_STYLE
+
+
+def test_select_resolves_the_default_to_a_real_choice(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def capture(message, **kwargs):
+        captured.update(kwargs)
+        return _StubQuestion("b")
+
+    monkeypatch.setattr(questionary, "select", capture)
+    service = PromptService(interactive=True)
+    service.select("Pick", [Choice("a", "A"), Choice("b", "B")], default="b")
+
+    assert captured["default"].value == "b"
+
+
+def test_select_tolerates_a_default_that_is_not_offered(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def capture(message, **kwargs):
+        captured.update(kwargs)
+        return _StubQuestion("a")
+
+    monkeypatch.setattr(questionary, "select", capture)
+    PromptService(interactive=True).select("Pick", [Choice("a", "A")], default="missing")
+
+    # Questionary rejects a default that is not among the choices, so an unknown
+    # one must degrade to "no default" rather than blow up mid-prompt.
+    assert captured["default"] is None
+
+
+# --- end-to-end keystrokes ------------------------------------------------
+
+
+def test_checkbox_choices_toggle_with_the_space_bar() -> None:
+    """The interaction the CLI advertises: space toggles, enter confirms."""
+    choices = [
+        Choice("Codex", "Codex", ".agents/skills/agentflow"),
+        Choice("Claude", "Claude", ".claude/skills/agentflow", checked=True),
+        Choice("GitHub", "GitHub", ".github/skills/agentflow"),
+    ]
+    with create_pipe_input() as pipe:
+        # space (toggle Codex on) · down · down · space (toggle GitHub on) · enter
+        pipe.send_text(" \x1b[B\x1b[B \r")
+        answer = questionary.checkbox(
+            "Which agents?",
+            choices=[choice.to_questionary() for choice in choices],
+            style=PROMPT_STYLE,
+            input=pipe,
+            output=DummyOutput(),
+        ).unsafe_ask()
+
+    assert answer == ["Codex", "Claude", "GitHub"]
+
+
+def test_prechecked_choices_come_back_without_any_keystrokes() -> None:
+    choices = [
+        Choice("Codex", "Codex", checked=False),
+        Choice("Claude", "Claude", checked=True),
+    ]
+    with create_pipe_input() as pipe:
+        pipe.send_text("\r")
+        answer = questionary.checkbox(
+            "Which agents?",
+            choices=[choice.to_questionary() for choice in choices],
+            style=PROMPT_STYLE,
+            input=pipe,
+            output=DummyOutput(),
+        ).unsafe_ask()
+
+    assert answer == ["Claude"]

--- a/tests/unit_tests/test_cli_steps.py
+++ b/tests/unit_tests/test_cli_steps.py
@@ -1,0 +1,203 @@
+"""Tests for step timelines and determinate progress runs."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+from agentflow_cli.cli.core.steps import (
+    LiveProgressRun,
+    LiveTimeline,
+    QuietTimeline,
+    StaticProgressRun,
+    StaticTimeline,
+    StepState,
+    StructuredProgressRun,
+    StructuredTimeline,
+    format_elapsed,
+)
+from agentflow_cli.cli.core.theme import UNICODE_GLYPHS
+
+
+STEPS = (("one", "First stage"), ("two", "Second stage"))
+
+
+def static(emitted: list[str]) -> StaticTimeline:
+    return StaticTimeline(
+        glyphs=UNICODE_GLYPHS,
+        emit=emitted.append,
+        title="Doing work",
+        steps=STEPS,
+    )
+
+
+def test_format_elapsed_switches_to_minutes() -> None:
+    assert format_elapsed(0.04) == "0.0s"
+    assert format_elapsed(12.34) == "12.3s"
+    assert format_elapsed(63.0) == "1m 03s"
+    assert format_elapsed(3600.0) == "60m 00s"
+
+
+def test_static_timeline_reports_each_transition() -> None:
+    emitted: list[str] = []
+    with static(emitted) as timeline:
+        with timeline.step("one") as step:
+            step.detail("resolved config")
+        with timeline.step("two"):
+            pass
+
+    assert emitted[0].endswith("Doing work")
+    assert any("First stage" in line and "resolved config" in line for line in emitted)
+    assert sum(line.startswith(UNICODE_GLYPHS.check) for line in emitted) == 2
+
+
+def test_timeline_marks_a_raising_step_as_failed_and_reraises() -> None:
+    emitted: list[str] = []
+    timeline = static(emitted)
+    with pytest.raises(RuntimeError, match="boom"), timeline:
+        with timeline.step("one"):
+            raise RuntimeError("boom")
+
+    assert timeline.failed is True
+    assert any(line.startswith(UNICODE_GLYPHS.cross) for line in emitted)
+
+
+def test_skipped_step_is_neither_done_nor_failed() -> None:
+    emitted: list[str] = []
+    timeline = static(emitted)
+    with timeline, timeline.step("one") as step:
+        step.skip("nothing to do")
+
+    assert timeline._index["one"].state is StepState.SKIPPED
+    assert timeline.failed is False
+    assert any("nothing to do" in line for line in emitted)
+
+
+def test_timeline_accepts_stages_discovered_at_runtime() -> None:
+    emitted: list[str] = []
+    timeline = static(emitted)
+    with timeline:
+        timeline.add("three", "Third stage")
+        with timeline.step("three"):
+            pass
+        # An unknown key still runs rather than raising, so a command can
+        # report work it only learned about mid-flight.
+        with timeline.step("four", "Fourth stage"):
+            pass
+
+    assert [step.key for step in timeline._steps] == ["one", "two", "three", "four"]
+    assert any("Fourth stage" in line for line in emitted)
+
+
+def test_structured_timeline_emits_versioned_lifecycle_events() -> None:
+    events: list[tuple[str, str, dict]] = []
+    timeline = StructuredTimeline(
+        emit=lambda event, message, data: events.append((event, message, data)),
+        title="Doing work",
+        steps=STEPS,
+    )
+    with timeline, timeline.step("one") as step:
+        step.detail("resolved config")
+
+    names = [event for event, _, _ in events]
+    assert names == ["timeline_start", "step_start", "step_end", "timeline_end"]
+    assert events[2][2]["status"] == "done"
+    assert events[2][2]["detail"] == "resolved config"
+    assert events[-1][2]["status"] == "completed"
+
+
+def test_structured_timeline_reports_failure_status() -> None:
+    events: list[tuple[str, str, dict]] = []
+    timeline = StructuredTimeline(
+        emit=lambda event, message, data: events.append((event, message, data)),
+        steps=STEPS,
+    )
+    with pytest.raises(ValueError, match="nope"), timeline:
+        with timeline.step("one"):
+            raise ValueError("nope")
+
+    assert events[-1][2]["status"] == "failed"
+
+
+def test_quiet_timeline_produces_no_output_but_still_runs_work() -> None:
+    ran = []
+    timeline = QuietTimeline(STEPS)
+    with timeline, timeline.step("one"):
+        ran.append("worked")
+    assert ran == ["worked"]
+
+
+def test_live_timeline_leaves_its_final_state_in_the_buffer() -> None:
+    stream = io.StringIO()
+    console = Console(file=stream, force_terminal=True, width=100, legacy_windows=False)
+    timeline = LiveTimeline(
+        console,
+        glyphs=UNICODE_GLYPHS,
+        title="Doing work",
+        steps=STEPS,
+    )
+    with timeline:
+        with timeline.step("one") as step:
+            step.detail("resolved config")
+        with timeline.step("two"):
+            pass
+
+    rendered = stream.getvalue()
+    assert "First stage" in rendered
+    assert "Second stage" in rendered
+    assert "resolved config" in rendered
+
+
+def test_progress_run_tracks_a_pass_fail_tally() -> None:
+    emitted: list[str] = []
+    run = StaticProgressRun(
+        total=3,
+        title="Running cases",
+        glyphs=UNICODE_GLYPHS,
+        emit=emitted.append,
+    )
+    with run:
+        run.record("a", status="passed")
+        run.record("b", status="failed", detail="0.4s")
+        run.record("c", status="passed")
+
+    assert run.completed == 3
+    assert run.tally == {"passed": 2, "failed": 1, "error": 0, "skipped": 0}
+    assert "[  2/3]" in emitted[2]
+    assert "FAILED" in emitted[2]
+
+
+def test_structured_progress_run_emits_one_event_per_item() -> None:
+    events: list[tuple[str, str, dict]] = []
+    run = StructuredProgressRun(
+        total=2,
+        title="Running cases",
+        emit=lambda event, message, data: events.append((event, message, data)),
+    )
+    with run:
+        run.record("a", status="passed")
+        run.record("b", status="error")
+
+    assert [event for event, _, _ in events] == [
+        "progress_start",
+        "progress",
+        "progress",
+        "progress_end",
+    ]
+    assert events[1][2]["completed"] == 1
+    assert events[-1][2]["error"] == 1
+
+
+def test_live_progress_run_renders_results_above_its_bar() -> None:
+    stream = io.StringIO()
+    console = Console(file=stream, force_terminal=True, width=100, legacy_windows=False)
+    with LiveProgressRun(console, total=2, title="Running cases", glyphs=UNICODE_GLYPHS) as run:
+        run.record("weather::tokyo", status="passed", detail="0.4s")
+        run.record("weather::oslo", status="failed", detail="0.5s")
+
+    rendered = stream.getvalue()
+    assert "weather::tokyo" in rendered
+    assert "weather::oslo" in rendered
+    assert run.tally["failed"] == 1

--- a/tests/unit_tests/test_cli_theme.py
+++ b/tests/unit_tests/test_cli_theme.py
@@ -1,0 +1,83 @@
+"""Tests for the brand palette, glyph sets, and gradient helpers."""
+
+from __future__ import annotations
+
+from agentflow_cli.cli.core.theme import (
+    ASCII_GLYPHS,
+    BRAND_RAMP,
+    UNICODE_GLYPHS,
+    dim_hex,
+    glyphs_for,
+    gradient_rule,
+    gradient_text,
+    sample_ramp,
+)
+
+
+def test_ramp_endpoints_are_exact() -> None:
+    assert sample_ramp(0.0) == BRAND_RAMP[0]
+    assert sample_ramp(1.0) == BRAND_RAMP[-1]
+
+
+def test_ramp_is_clamped_outside_the_unit_interval() -> None:
+    assert sample_ramp(-5.0) == BRAND_RAMP[0]
+    assert sample_ramp(12.0) == BRAND_RAMP[-1]
+
+
+def test_ramp_interpolates_between_stops() -> None:
+    # A midpoint between two stops must be a new color, not either neighbour,
+    # or wide gradient bars would show visible banding.
+    midpoint = sample_ramp(0.5 / (len(BRAND_RAMP) - 1))
+    assert midpoint not in {BRAND_RAMP[0], BRAND_RAMP[1]}
+    assert midpoint.startswith("#") and len(midpoint) == 7
+
+
+def test_ramp_handles_degenerate_palettes() -> None:
+    assert sample_ramp(0.4, ()) == "#ffffff"
+    assert sample_ramp(0.4, ("#123456",)) == "#123456"
+
+
+def test_dim_hex_scales_toward_black_and_clamps() -> None:
+    assert dim_hex("#ffffff", 0.5) == "#808080"
+    assert dim_hex("#ffffff", 0.0) == "#000000"
+    assert dim_hex("#abcdef", 5.0) == "#abcdef"
+
+
+def test_gradient_text_styles_every_character_distinctly() -> None:
+    text = gradient_text("agentflow", bold=True)
+    assert text.plain == "agentflow"
+    styles = [span.style for span in text.spans]
+    assert len(styles) == len("agentflow")
+    assert all(style.startswith("bold #") for style in styles)
+    assert len(set(styles)) > 1
+
+
+def test_gradient_text_offset_shifts_the_sweep() -> None:
+    base = [span.style for span in gradient_text("agentflow").spans]
+    shifted = [span.style for span in gradient_text("agentflow", offset=0.5).spans]
+    assert base != shifted
+
+
+def test_gradient_rule_matches_requested_width() -> None:
+    rule = gradient_rule(24, glyphs=UNICODE_GLYPHS)
+    assert len(rule.plain) == 24
+    assert set(rule.plain) == {UNICODE_GLYPHS.rule}
+
+
+def test_glyph_selection_follows_encoding_support() -> None:
+    assert glyphs_for(True) is UNICODE_GLYPHS
+    assert glyphs_for(False) is ASCII_GLYPHS
+
+
+def test_ascii_glyphs_are_pure_ascii() -> None:
+    for field in (
+        ASCII_GLYPHS.check,
+        ASCII_GLYPHS.cross,
+        ASCII_GLYPHS.arrow,
+        ASCII_GLYPHS.pending,
+        ASCII_GLYPHS.tree_branch,
+        ASCII_GLYPHS.cursor,
+        *ASCII_GLYPHS.spinner,
+        *ASCII_GLYPHS.shades,
+    ):
+        assert field.isascii(), f"{field!r} is not ASCII"

--- a/tests/unit_tests/test_cli_user_config.py
+++ b/tests/unit_tests/test_cli_user_config.py
@@ -1,0 +1,56 @@
+"""User configuration persistence and command tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentflow_cli.cli.exceptions import ConfigurationError
+from agentflow_cli.cli.user_config import UserConfigStore, parse_config_value
+
+
+def test_store_round_trip_and_unset(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    store = UserConfigStore(path)
+    assert store.load() == {"schema_version": 1}
+
+    store.set("output.format", "plain")
+    store.set("updates.enabled", False)
+    assert store.get("output.format") == "plain"
+    assert store.get("updates.enabled") is False
+    assert store.get("missing", "fallback") == "fallback"
+    assert store.unset("output.format") is True
+    assert store.unset("output.format") is False
+
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["schema_version"] == 1
+    assert persisted["updates"]["enabled"] is False
+
+
+def test_store_rejects_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    path.write_text("{invalid", encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="Could not read"):
+        UserConfigStore(path).load()
+
+
+def test_store_rejects_scalar_parent(tmp_path: Path) -> None:
+    store = UserConfigStore(tmp_path / "config.json")
+    store.set("output", "plain")
+    with pytest.raises(ConfigurationError, match="scalar"):
+        store.set("output.format", "json")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("true", True),
+        ("42", 42),
+        ('{"a": 1}', {"a": 1}),
+        ("plain", "plain"),
+    ],
+)
+def test_parse_config_value(raw, expected) -> None:
+    assert parse_config_value(raw) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -33,11 +33,13 @@ dependencies = [
     { name = "fastapi" },
     { name = "gunicorn" },
     { name = "orjson" },
+    { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "questionary" },
+    { name = "rich" },
     { name = "typer" },
     { name = "uvicorn" },
 ]
@@ -109,6 +111,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = ">=0.40b0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "orjson", specifier = ">=3.11,<4" },
+    { name = "platformdirs", specifier = ">=4.0,<5" },
     { name = "pydantic", specifier = ">=2.13,<3" },
     { name = "pydantic-settings", specifier = ">=2.3,<3" },
     { name = "pyjwt", marker = "extra == 'jwt'", specifier = ">=2.8,<3" },
@@ -116,6 +119,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.19,<0.1" },
     { name = "questionary", specifier = ">=2.0,<3" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.7,<7" },
+    { name = "rich", specifier = ">=14.0,<15" },
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.10.0" },
     { name = "snowflakekit", marker = "extra == 'snowflakekit'", specifier = ">=0.1.1,<1.0" },
     { name = "textxtract", extras = ["pdf", "docx", "html", "xml", "md"], marker = "extra == 'media'", specifier = ">=0.2.0" },
@@ -2293,15 +2297,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "15.0.0"
+version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Rebuilds the `agentflow` CLI's terminal experience and the runtime underneath it. Three layers:

**Runtime.** Commands load lazily, so a broken optional dependency can no longer take down `--help`, `--version`, or unrelated commands. One root callback resolves output format, colour, progress, verbosity, and working directory; one exception boundary maps errors to stable codes (`AF-CONFIG-001`, `AF-DEPS-001`, …) with recovery hints.

**Presentation.** A shared brand palette and glyph set, a full-screen application surface with pinned chrome, an animated command intro, live step timelines, and determinate progress. Every animated surface has a plain line-per-transition renderer and a versioned JSON/JSONL event renderer, selected automatically from terminal capabilities.

**Interaction.** One guided-prompt service behind every question, so prompts share a theme, a cancellation contract, and one non-interactive policy.

## The full-screen surface

On an interactive terminal a command now runs on its own screen:

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ← pinned
 ◆ agentflow ▸ play                                  0.5.0
 Starting development server via Uvicorn.
───────────────────────────────────────────────────────────
                                                            ← body scrolls
  ◆ Preparing the Agentflow runtime                            here only
  ┣─ ✓ Validating project configuration           0.2s
  ┃   agentflow.json
  ┣─ ⠹ Loading environment and graph runtime      1.4s
  ...
───────────────────────────────────────────────────────────
 ▸ Ctrl+C to stop the development server    agentflow play   ← pinned
```

Pinning uses a DEC scrolling region rather than a Rich `Layout`. That matters: a layout would require every line of output to be routed through one renderable, which breaks the moment a command shells out to pytest, streams Uvicorn logs, or hands the terminal to a prompt. A scrolling region is enforced by the terminal, so all of those simply scroll inside the body.

Because a terminal *discards* an alternate screen when it is released, the surface is held until you press Enter — otherwise a fast command erases its own result. Release is wrapped in a `finally` so a crash can never leave your shell on an alternate buffer or inside a scrolling region. `--no-fullscreen` / `AGENTFLOW_NO_FULLSCREEN=1` keeps everything in normal scrollback instead.

The screen is claimed lazily by the first command that renders a header, so `--version`, `config get`, and `--format json` never take over the terminal or pause on exit.

## Progress that reports actual work

Commands declare their stages up front, so the whole plan is visible from the first frame: pending stages dimmed, the running one animated with an elapsed timer and a live detail line. Wired into `play`/`dev`/`api`, `init`, `build`, `test`, `doctor`, and `skills`. `eval` uses a determinate bar with a running pass/fail tally, per-case results scrolling above it.

## Interactive prompts

`agentflow skills` now picks agents from an arrow-key checklist where **space toggles** and enter confirms, instead of typing a menu number. Each row shows its install path, already-installed agents are labelled and pre-checked, and choosing one that exists offers to overwrite rather than failing. `init` prompts explain each option inline.

## Notable fixes

- **The alternate screen erased command output.** It was held through a Rich live display, which re-homes the cursor before every write, then released on exit — which discards the buffer. Short commands showed a flash of nothing.
- **A new `Console` was built per call**, so a live display could not tell that ordinary prints belonged to it; background output collided with spinners instead of scrolling above them.
- **Prompts wiped the pinned footer.** prompt-toolkit erases from the cursor to the end of the *screen*, past the scrolling region. Chrome is repainted after each answer.
- **`stdin.isatty()` is not enough on Windows.** Under MSYS/Cygwin shells it reports true but prompt-toolkit cannot attach to a console and raises, surfacing as `AF-INTERNAL-001: Found xterm-256color, while expecting a Windows console`. Availability is probed, and such a terminal correctly counts as non-interactive.
- A legacy console that reports as a terminal but refuses the alternate buffer now aborts before writing, rather than leaving a scrolling region on the user's real scrollback.
- Project config discovery walks parent directories, so commands run from a nested package resolve the nearest project.
- CLI logging uses one invocation-wide handler; quiet and verbose apply consistently without duplicate records.

## Compatibility

- `api` and `play` remain as documented aliases; `dev` is the new goal-oriented name.
- `skills --agent/--all/--list/--force` all keep their existing behaviour and exit codes. Naming one agent that is already installed still fails with a non-zero exit; `--all` and multi-select skip what exists.
- New: `doctor`, `demo`, `config list|get|set|unset|path|validate`, root `-V/--version`, and the global output flags.

## Testing

1048 tests pass; mypy, ruff, and the pre-commit hook set are clean. New coverage for the palette, timelines, progress runs, the intro engine, the prompt service, terminal capabilities, and user config — including a test that drives the checkbox through a prompt-toolkit pipe to assert space-toggling, and one asserting the scrolling region is always released.

## Reviewer notes

- Adds `rich` and `platformdirs` as direct dependencies (both were already transitive).
- `CLI_UX_IMPLEMENTATION_PLAN.md` is intentionally not committed — it is a pre-implementation proposal that this branch diverges from in places, so shipping it would be stale from day one. Say the word if you want it in the repo.
